### PR TITLE
Unique address count approximations in batch info cache

### DIFF
--- a/vumi_message_store/batch_info_cache.py
+++ b/vumi_message_store/batch_info_cache.py
@@ -335,6 +335,18 @@ class BatchInfoCache(object):
         """
         return self._get_counter_value(self.event_count_key(batch_id))
 
+    def get_from_addr_count(self, batch_id):
+        """
+        Return the count of from addresses.
+        """
+        return self.redis.pfcount(self.from_addr_key(batch_id))
+
+    def get_to_addr_count(self, batch_id):
+        """
+        Return the count of to addresses.
+        """
+        return self.redis.pfcount(self.to_addr_key(batch_id))
+
     @Manager.calls_manager
     def rebuild_cache(self, batch_id, qms, page_size=None):
         """

--- a/vumi_message_store/message_store.py
+++ b/vumi_message_store/message_store.py
@@ -263,3 +263,9 @@ class QueryMessageStore(object):
 
     def get_batch_event_count(self, batch_id):
         return self.batch_info_cache.get_event_count(batch_id)
+
+    def get_batch_from_addr_count(self, batch_id):
+        return self.batch_info_cache.get_from_addr_count(batch_id)
+
+    def get_batch_to_addr_count(self, batch_id):
+        return self.batch_info_cache.get_to_addr_count(batch_id)

--- a/vumi_message_store/tests/test_batch_info_cache.py
+++ b/vumi_message_store/tests/test_batch_info_cache.py
@@ -112,6 +112,9 @@ class TestBatchInfoCache(VumiTestCase):
         batch identifier from the set of batches we're tracking.
         """
         yield self.batch_info_cache.batch_start("mybatch")
+        # Obsolete keys that we no longer use but should still clear.
+        yield self.redis.zadd("batches:to_addr:mybatch", foo=123)
+        yield self.redis.zadd("batches:from_addr:mybatch", foo=123)
         timestamp = to_timestamp(datetime.utcnow())
         yield self.batch_info_cache.add_inbound_message_key(
             "mybatch", "in", timestamp)
@@ -128,6 +131,8 @@ class TestBatchInfoCache(VumiTestCase):
             "batches:outbound_count:mybatch",
             "batches:event_count:mybatch",
             "batches:status:mybatch",
+            "batches:to_addr:mybatch",
+            "batches:from_addr:mybatch",
         ])
         yield self.assert_redis_set("batches", ["mybatch"])
 

--- a/vumi_message_store/tests/test_message_store.py
+++ b/vumi_message_store/tests/test_message_store.py
@@ -1464,3 +1464,45 @@ class TestQueryMessageStore(VumiTestCase):
         """
         count = yield self.store.get_batch_event_count("batch")
         self.assertEqual(count, 0)
+
+    @inlineCallbacks
+    def test_get_batch_from_addr_count(self):
+        """
+        The from_addr count can be queried.
+        """
+        yield self.bi_cache.batch_start("batch")
+        yield self.bi_cache.add_from_addr("batch", "addr-1")
+        yield self.bi_cache.add_from_addr("batch", "addr-2")
+        yield self.bi_cache.add_from_addr("batch", "addr-3")
+
+        count = yield self.store.get_batch_from_addr_count("batch")
+        self.assertEqual(count, 3)
+
+    @inlineCallbacks
+    def test_get_batch_from_addr_count_no_batch(self):
+        """
+        The from_addr count returns zero for missing batches.
+        """
+        count = yield self.store.get_batch_from_addr_count("batch")
+        self.assertEqual(count, 0)
+
+    @inlineCallbacks
+    def test_get_batch_to_addr_count(self):
+        """
+        The to_addr count can be queried.
+        """
+        yield self.bi_cache.batch_start("batch")
+        yield self.bi_cache.add_to_addr("batch", "addr-1")
+        yield self.bi_cache.add_to_addr("batch", "addr-2")
+        yield self.bi_cache.add_to_addr("batch", "addr-3")
+
+        count = yield self.store.get_batch_to_addr_count("batch")
+        self.assertEqual(count, 3)
+
+    @inlineCallbacks
+    def test_get_batch_to_addr_count_no_batch(self):
+        """
+        The to_addr count returns zero for missing batches.
+        """
+        count = yield self.store.get_batch_to_addr_count("batch")
+        self.assertEqual(count, 0)


### PR DESCRIPTION
We can use the HyperLogLog functionality in Redis for this.
