### PR TITLE
Fix model migration tests

### DIFF
--- a/vumi_message_store/migrators.py
+++ b/vumi_message_store/migrators.py
@@ -119,7 +119,7 @@ class InboundMessageMigrator(MessageMigratorBase):
 
     def reverse_from_3(self, mdata):
         # The only difference between v2 and v3 is an index that's computed at
-        # save time, to the reverse migration is identical to the forward
+        # save time, so the reverse migration is identical to the forward
         # migration except for the version we set.
         mdata.set_value('$VERSION', 2)
         self._copy_msg_field('msg', mdata)

--- a/vumi_message_store/migrators.py
+++ b/vumi_message_store/migrators.py
@@ -59,7 +59,7 @@ class OutboundMessageMigrator(MessageMigratorBase):
         mdata.set_value('$VERSION', 2)
         self._copy_msg_field('msg', mdata)
         mdata.copy_values('batches')
-        mdata.copy_indexes('batches')
+        mdata.copy_indexes('batches_bin')
 
         return mdata
 
@@ -69,18 +69,20 @@ class OutboundMessageMigrator(MessageMigratorBase):
         mdata.set_value('$VERSION', 3)
         self._copy_msg_field('msg', mdata)
         mdata.copy_values('batches')
-        mdata.copy_indexes('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_timestamps_bin')
 
         return mdata
 
     def reverse_from_3(self, mdata):
         # The only difference between v2 and v3 is an index that's computed at
-        # save time, to the reverse migration is identical to the forward
+        # save time, so the reverse migration is identical to the forward
         # migration except for the version we set.
         mdata.set_value('$VERSION', 2)
         self._copy_msg_field('msg', mdata)
         mdata.copy_values('batches')
-        mdata.copy_indexes('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_timestamps_bin')
 
         return mdata
 
@@ -100,7 +102,7 @@ class InboundMessageMigrator(MessageMigratorBase):
         mdata.set_value('$VERSION', 2)
         self._copy_msg_field('msg', mdata)
         mdata.copy_values('batches')
-        mdata.copy_indexes('batches')
+        mdata.copy_indexes('batches_bin')
 
         return mdata
 
@@ -110,7 +112,8 @@ class InboundMessageMigrator(MessageMigratorBase):
         mdata.set_value('$VERSION', 3)
         self._copy_msg_field('msg', mdata)
         mdata.copy_values('batches')
-        mdata.copy_indexes('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_timestamps_bin')
 
         return mdata
 
@@ -121,6 +124,7 @@ class InboundMessageMigrator(MessageMigratorBase):
         mdata.set_value('$VERSION', 2)
         self._copy_msg_field('msg', mdata)
         mdata.copy_values('batches')
-        mdata.copy_indexes('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_timestamps_bin')
 
         return mdata


### PR DESCRIPTION
The underlying model code in vumi now handles indexes differently, which means a bunch of migration tests fail.
