### PR TITLE
Ensure Riak clients are properly cleaned up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ before_script:
   - riak-admin member-status
 script:
   - if [ -z "$NO_COVERAGE" ]; then COVERAGE_CMD="coverage run --source=vumi_message_store"; else COVERAGE_CMD=""; fi
-  - $COVERAGE_CMD `which trial` vumi_message_store
+  - VUMI_TEST_ASSERT_CLOSED=true $COVERAGE_CMD `which trial` vumi_message_store
 after_success:
   - if [ -z "$NO_COVERAGE" ]; then coveralls; fi

--- a/vumi_message_store/tests/test_batch_info_cache.py
+++ b/vumi_message_store/tests/test_batch_info_cache.py
@@ -1037,6 +1037,7 @@ class TestBatchInfoCache(VumiTestCase):
         riak_persistence_helper = self.add_helper(
             PersistenceHelper(use_riak=True))
         manager = riak_persistence_helper.get_riak_manager()
+        self.add_cleanup(manager.close_manager)
         qms = QueryMessageStore(manager, self.redis)
         backend = qms.riak_backend
 
@@ -1129,6 +1130,7 @@ class TestBatchInfoCache(VumiTestCase):
         riak_persistence_helper = self.add_helper(
             PersistenceHelper(use_riak=True))
         manager = riak_persistence_helper.get_riak_manager()
+        self.add_cleanup(manager.close_manager)
         qms = QueryMessageStore(manager, self.redis)
         backend = qms.riak_backend
 
@@ -1208,6 +1210,7 @@ class TestBatchInfoCache(VumiTestCase):
         riak_persistence_helper = self.add_helper(
             PersistenceHelper(use_riak=True))
         manager = riak_persistence_helper.get_riak_manager()
+        self.add_cleanup(manager.close_manager)
         qms = QueryMessageStore(manager, self.redis)
 
         yield self.assert_redis_keys([])

--- a/vumi_message_store/tests/test_message_store.py
+++ b/vumi_message_store/tests/test_message_store.py
@@ -33,6 +33,7 @@ class TestMessageStoreBatchManager(VumiTestCase):
         self.persistence_helper = self.add_helper(
             PersistenceHelper(use_riak=True))
         self.manager = self.persistence_helper.get_riak_manager()
+        self.add_cleanup(self.manager.close_manager)
         self.redis = yield self.persistence_helper.get_redis_manager()
         self.batch_manager = MessageStoreBatchManager(self.manager, self.redis)
         self.backend = self.batch_manager.riak_backend
@@ -180,6 +181,7 @@ class TestOperationalMessageStore(VumiTestCase):
         self.persistence_helper = self.add_helper(
             PersistenceHelper(use_riak=True))
         self.manager = self.persistence_helper.get_riak_manager()
+        self.add_cleanup(self.manager.close_manager)
         self.redis = yield self.persistence_helper.get_redis_manager()
         self.store = OperationalMessageStore(self.manager, self.redis)
         self.backend = self.store.riak_backend
@@ -650,6 +652,7 @@ class TestQueryMessageStore(VumiTestCase):
         self.persistence_helper = self.add_helper(
             PersistenceHelper(use_riak=True))
         self.manager = self.persistence_helper.get_riak_manager()
+        self.add_cleanup(self.manager.close_manager)
         self.redis = yield self.persistence_helper.get_redis_manager()
         self.store = QueryMessageStore(self.manager, self.redis)
         self.backend = self.store.riak_backend

--- a/vumi_message_store/tests/test_migrators.py
+++ b/vumi_message_store/tests/test_migrators.py
@@ -561,6 +561,7 @@ class TestEventMigrator(EventMigratorTestMixin, VumiTestCase):
         self.persistence_helper = self.add_helper(
             PersistenceHelper(use_riak=True))
         self.manager = self.persistence_helper.get_riak_manager()
+        self.add_cleanup(self.manager.close_manager)
         self.msg_helper = self.add_helper(MessageHelper())
         self.set_up_proxies()
 
@@ -571,6 +572,7 @@ class TestOutboundMessageMigrator(OutboundMessageMigratorTestMixin,
         self.persistence_helper = self.add_helper(
             PersistenceHelper(use_riak=True))
         self.manager = self.persistence_helper.get_riak_manager()
+        self.add_cleanup(self.manager.close_manager)
         self.msg_helper = self.add_helper(MessageHelper())
         self.set_up_proxies()
 
@@ -581,6 +583,7 @@ class TestInboundMessageMigrator(InboundMessageMigratorTestMixin,
         self.persistence_helper = self.add_helper(
             PersistenceHelper(use_riak=True))
         self.manager = self.persistence_helper.get_riak_manager()
+        self.add_cleanup(self.manager.close_manager)
         self.msg_helper = self.add_helper(MessageHelper())
         self.set_up_proxies()
 

--- a/vumi_message_store/tests/test_riak_backend.py
+++ b/vumi_message_store/tests/test_riak_backend.py
@@ -1215,7 +1215,9 @@ class TestMessageStoreRiakBackend(RiakBackendTestMixin, VumiTestCase):
     def setUp(self):
         self.persistence_helper = self.add_helper(
             PersistenceHelper(use_riak=True))
-        self.set_up_tests(self.persistence_helper.get_riak_manager())
+        manager = self.persistence_helper.get_riak_manager()
+        self.add_cleanup(manager.close_manager)
+        self.set_up_tests(manager)
 
 
 class TestMessageStoreRiakBackendInMemory(RiakBackendTestMixin, VumiTestCase):
@@ -1231,7 +1233,9 @@ class TestMessageStoreRiakBackendSync(RiakBackendTestMixin, VumiTestCase):
     def setUp(self):
         self.persistence_helper = self.add_helper(
             PersistenceHelper(use_riak=True, is_sync=True))
-        self.set_up_tests(self.persistence_helper.get_riak_manager())
+        manager = self.persistence_helper.get_riak_manager()
+        self.add_cleanup(manager.close_manager)
+        self.set_up_tests(manager)
 
 
 class TestMessageStoreRiakBackendInMemorySync(RiakBackendTestMixin,


### PR DESCRIPTION
Newer vumi requires Riak managers to be cleaned up properly, and we don't yet do that cleanup here.
