### PR TITLE
Update model schemas

### DIFF
--- a/vumi_message_store/memory_backend_manager.py
+++ b/vumi_message_store/memory_backend_manager.py
@@ -175,8 +175,8 @@ class FakeRiakState(object):
         """
         new_bucket_indexes = {}
         for index_name, index_values in bucket_indexes.iteritems():
-            new_index_values = list(filter(
-                lambda (_, key): key != fake_object.key, index_values))
+            new_index_values = [(value, key) for value, key in index_values
+                                if key != fake_object.key]
 
             if new_index_values:
                 new_bucket_indexes[index_name] = new_index_values

--- a/vumi_message_store/memory_backend_manager.py
+++ b/vumi_message_store/memory_backend_manager.py
@@ -165,34 +165,28 @@ class FakeRiakState(object):
             "content_type": fake_object._current_data["content_type"],
             "data": json.dumps(fake_object._current_data["data"]),
         }
-        indexes = {}
+
+        bucket["indexes"] = (
+            self._rebuild_bucket_indexes(fake_object, bucket["indexes"]))
+
+    def _rebuild_bucket_indexes(self, fake_object, bucket_indexes):
+        """
+        Clears any existing indexes for the object and adds the new indexes.
+        """
+        new_bucket_indexes = {}
+        for index_name, index_values in bucket_indexes.iteritems():
+            new_index_values = list(filter(
+                lambda (_, key): key != fake_object.key, index_values))
+
+            if new_index_values:
+                new_bucket_indexes[index_name] = new_index_values
+
         for index_name, index_value in fake_object._current_data["indexes"]:
-            indexes.setdefault(index_name, []).append(
-                (index_value, fake_object.key))
+            new_index_values = new_bucket_indexes.setdefault(index_name, [])
+            new_index_values.append((index_value, fake_object.key))
+            new_index_values.sort()
 
-        bucket["indexes"] = self._filter_old_indexes(
-            fake_object, bucket["indexes"])
-
-        for index_name, index_values in indexes.iteritems():
-            old_indexes = bucket["indexes"].get(index_name, [])
-            new_indexes = [
-                (value, key) for value, key in old_indexes
-                if key != fake_object.key]
-            new_indexes.extend(index_values)
-            new_indexes.sort()
-            bucket["indexes"][index_name] = new_indexes
-
-    def _filter_old_indexes(self, fake_object, global_indexes):
-        """
-        Remove the object's key from indexes it no longer specifies
-        """
-        filtered_indexes = {}
-        for index_name, index_data in global_indexes.iteritems():
-            if index_name not in fake_object._current_data["indexes"]:
-                index_data = list(filter(
-                    lambda (_, key): key != fake_object.key, index_data))
-            filtered_indexes[index_name] = index_data
-        return filtered_indexes
+        return new_bucket_indexes
 
     def _reload_object_state(self, fake_object):
         """

--- a/vumi_message_store/memory_backend_manager.py
+++ b/vumi_message_store/memory_backend_manager.py
@@ -169,6 +169,10 @@ class FakeRiakState(object):
         for index_name, index_value in fake_object._current_data["indexes"]:
             indexes.setdefault(index_name, []).append(
                 (index_value, fake_object.key))
+
+        bucket["indexes"] = self._filter_old_indexes(
+            fake_object, bucket["indexes"])
+
         for index_name, index_values in indexes.iteritems():
             old_indexes = bucket["indexes"].get(index_name, [])
             new_indexes = [
@@ -177,6 +181,18 @@ class FakeRiakState(object):
             new_indexes.extend(index_values)
             new_indexes.sort()
             bucket["indexes"][index_name] = new_indexes
+
+    def _filter_old_indexes(self, fake_object, global_indexes):
+        """
+        Remove the object's key from indexes it no longer specifies
+        """
+        filtered_indexes = {}
+        for index_name, index_data in global_indexes.iteritems():
+            if index_name not in fake_object._current_data["indexes"]:
+                index_data = list(filter(
+                    lambda (_, key): key != fake_object.key, index_data))
+            filtered_indexes[index_name] = index_data
+        return filtered_indexes
 
     def _reload_object_state(self, fake_object):
         """

--- a/vumi_message_store/message_store.py
+++ b/vumi_message_store/message_store.py
@@ -208,8 +208,8 @@ class QueryMessageStore(object):
     def list_batch_inbound_keys_with_addresses(self, batch_id, start=None,
                                                end=None, max_results=None):
         """
-        List inbound message keys with timestamps and addresses for the given
-        batch.
+        List inbound message keys with timestamps and addresses in ascending
+        timestamp order for the given batch.
         """
         return self.riak_backend.list_batch_inbound_keys_with_addresses(
             batch_id, start=start, end=end, max_results=max_results)
@@ -217,11 +217,33 @@ class QueryMessageStore(object):
     def list_batch_outbound_keys_with_addresses(self, batch_id, start=None,
                                                 end=None, max_results=None):
         """
-        List outbound message keys with timestamps and addresses for the given
-        batch.
+        List outbound message keys with timestamps and addresses in ascending
+        timestamp order for the given batch.
         """
         return self.riak_backend.list_batch_outbound_keys_with_addresses(
             batch_id, start=start, end=end, max_results=max_results)
+
+    def list_batch_inbound_keys_with_addresses_reverse(self, batch_id,
+                                                       start=None, end=None,
+                                                       max_results=None):
+        """
+        List inbound message keys with timestamps and addresses in ascending
+        timestamp order for the given batch.
+        """
+        return (self.riak_backend.
+                list_batch_inbound_keys_with_addresses_reverse(
+                    batch_id, start=start, end=end, max_results=max_results))
+
+    def list_batch_outbound_keys_with_addresses_reverse(self, batch_id,
+                                                        start=None, end=None,
+                                                        max_results=None):
+        """
+        List outbound message keys with timestamps and addresses in ascending
+        timestamp order for the given batch.
+        """
+        return (self.riak_backend.
+                list_batch_outbound_keys_with_addresses_reverse(
+                    batch_id, start=start, end=end, max_results=max_results))
 
     def list_message_event_keys_with_statuses(self, message_id,
                                               max_results=None):

--- a/vumi_message_store/message_store.py
+++ b/vumi_message_store/message_store.py
@@ -227,7 +227,7 @@ class QueryMessageStore(object):
                                                        start=None, end=None,
                                                        max_results=None):
         """
-        List inbound message keys with timestamps and addresses in ascending
+        List inbound message keys with timestamps and addresses in descending
         timestamp order for the given batch.
         """
         return (self.riak_backend.
@@ -238,7 +238,7 @@ class QueryMessageStore(object):
                                                         start=None, end=None,
                                                         max_results=None):
         """
-        List outbound message keys with timestamps and addresses in ascending
+        List outbound message keys with timestamps and addresses in descending
         timestamp order for the given batch.
         """
         return (self.riak_backend.

--- a/vumi_message_store/migrators.py
+++ b/vumi_message_store/migrators.py
@@ -43,6 +43,34 @@ class EventMigrator(MessageMigratorBase):
 
         return mdata
 
+    def migrate_from_1(self, mdata):
+        # If the old data contains a value for the `batches` field, it must be
+        # back-migrated from a newer version. If not, we have no way to know
+        # what batches the event belongs to, so we leave the field empty. Some
+        # external data migration tool will have to populate it.
+        mdata.set_value('$VERSION', 2)
+        self._copy_msg_field('event', mdata)
+        mdata.set_value('batches', mdata.old_data.get('batches', []))
+        mdata.copy_values('message')
+        mdata.copy_indexes('message_bin')
+        mdata.copy_indexes('message_with_status_bin')
+
+        return mdata
+
+    def reverse_from_2(self, mdata):
+        # We copy the `batches` field and related indexes even though the older
+        # model version doesn't know about them. This lets us migrate
+        # v2 -> v1 -> v2 without losing data.
+        mdata.set_value('$VERSION', 1)
+        self._copy_msg_field('event', mdata)
+        mdata.copy_values('message', 'batches')
+        mdata.copy_indexes('message_bin')
+        mdata.copy_indexes('message_with_status_bin')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_statuses_reverse_bin')
+
+        return mdata
+
 
 class OutboundMessageMigrator(MessageMigratorBase):
     def migrate_from_unversioned(self, mdata):
@@ -86,6 +114,56 @@ class OutboundMessageMigrator(MessageMigratorBase):
 
         return mdata
 
+    def migrate_from_3(self, mdata):
+        # We only copy existing fields and indexes over. The new fields and
+        # indexes are computed at save time.
+        mdata.set_value('$VERSION', 4)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_timestamps_bin')
+        mdata.copy_indexes('batches_with_addresses_bin')
+
+        return mdata
+
+    def reverse_from_4(self, mdata):
+        # The only difference between v3 and v4 is an index that's computed at
+        # save time, so the reverse migration is identical to the forward
+        # migration except for the version we set.
+        mdata.set_value('$VERSION', 3)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_timestamps_bin')
+        mdata.copy_indexes('batches_with_addresses_bin')
+
+        return mdata
+
+    def migrate_from_4(self, mdata):
+        # We copy existing fields and indexes over except for the indexes we're
+        # removing.
+        mdata.set_value('$VERSION', 5)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_addresses_bin')
+        mdata.copy_indexes('batches_with_addresses_reverse_bin')
+
+        return mdata
+
+    def reverse_from_5(self, mdata):
+        # The only difference between v4 and v5 is an index that's computed at
+        # save time, so the reverse migration is identical to the forward
+        # migration except for the version we set.
+        mdata.set_value('$VERSION', 4)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_addresses_bin')
+        mdata.copy_indexes('batches_with_addresses_reverse_bin')
+
+        return mdata
+
 
 class InboundMessageMigrator(MessageMigratorBase):
     def migrate_from_unversioned(self, mdata):
@@ -126,5 +204,55 @@ class InboundMessageMigrator(MessageMigratorBase):
         mdata.copy_values('batches')
         mdata.copy_indexes('batches_bin')
         mdata.copy_indexes('batches_with_timestamps_bin')
+
+        return mdata
+
+    def migrate_from_3(self, mdata):
+        # We only copy existing fields and indexes over. The new fields and
+        # indexes are computed at save time.
+        mdata.set_value('$VERSION', 4)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_timestamps_bin')
+        mdata.copy_indexes('batches_with_addresses_bin')
+
+        return mdata
+
+    def reverse_from_4(self, mdata):
+        # The only difference between v3 and v4 is an index that's computed at
+        # save time, so the reverse migration is identical to the forward
+        # migration except for the version we set.
+        mdata.set_value('$VERSION', 3)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_timestamps_bin')
+        mdata.copy_indexes('batches_with_addresses_bin')
+
+        return mdata
+
+    def migrate_from_4(self, mdata):
+        # We copy existing fields and indexes over except for the indexes we're
+        # removing.
+        mdata.set_value('$VERSION', 5)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_addresses_bin')
+        mdata.copy_indexes('batches_with_addresses_reverse_bin')
+
+        return mdata
+
+    def reverse_from_5(self, mdata):
+        # The only difference between v4 and v5 is an index that's computed at
+        # save time, so the reverse migration is identical to the forward
+        # migration except for the version we set.
+        mdata.set_value('$VERSION', 4)
+        self._copy_msg_field('msg', mdata)
+        mdata.copy_values('batches')
+        mdata.copy_indexes('batches_bin')
+        mdata.copy_indexes('batches_with_addresses_bin')
+        mdata.copy_indexes('batches_with_addresses_reverse_bin')
 
         return mdata

--- a/vumi_message_store/riak_backend.py
+++ b/vumi_message_store/riak_backend.py
@@ -10,6 +10,7 @@ from twisted.internet.defer import returnValue
 from vumi.persist.model import Manager
 
 from vumi_message_store.models import (
+    from_reverse_timestamp,
     Batch, CurrentTag, InboundMessage, OutboundMessage, Event)
 
 
@@ -228,10 +229,10 @@ class MessageStoreRiakBackend(object):
             max_results = self.DEFAULT_MAX_RESULTS
         start_value, end_value = self._start_end_values(batch_id, start, end)
         results = yield self.inbound_messages.index_keys_page(
-            'batches_with_timestamps', start_value, end_value,
+            'batches_with_addresses', start_value, end_value,
             return_terms=True, max_results=max_results)
         returnValue(IndexPageWrapper(
-            key_with_timestamp_formatter, self, batch_id, results))
+            key_with_ts_only_formatter, self, batch_id, results))
 
     @Manager.calls_manager
     def list_batch_outbound_keys_with_timestamps(self, batch_id, start=None,
@@ -243,10 +244,10 @@ class MessageStoreRiakBackend(object):
             max_results = self.DEFAULT_MAX_RESULTS
         start_value, end_value = self._start_end_values(batch_id, start, end)
         results = yield self.outbound_messages.index_keys_page(
-            'batches_with_timestamps', start_value, end_value,
+            'batches_with_addresses', start_value, end_value,
             return_terms=True, max_results=max_results)
         returnValue(IndexPageWrapper(
-            key_with_timestamp_formatter, self, batch_id, results))
+            key_with_ts_only_formatter, self, batch_id, results))
 
     @Manager.calls_manager
     def list_batch_inbound_keys_with_addresses(self, batch_id, start=None,
@@ -348,16 +349,6 @@ class IndexPageWrapper(object):
         return (self._formatter(self._batch_id, r) for r in self._index_page)
 
 
-def key_with_timestamp_formatter(batch_id, result):
-    value, key = result
-    prefix = batch_id + "$"
-    if not value.startswith(prefix):
-        raise ValueError(
-            "Index value %r does not begin with expected prefix %r." % (
-                value, prefix))
-    return (key, value[len(prefix):])
-
-
 def key_with_ts_and_value_formatter(batch_id, result):
     value, key = result
     prefix = batch_id + "$"
@@ -371,3 +362,13 @@ def key_with_ts_and_value_formatter(batch_id, result):
         raise ValueError(
             "Index value %r does not match expected format." % (value,))
     return (key, timestamp, address)
+
+
+def key_with_rts_and_value_formatter(batch_id, result):
+    key, reverse_ts, value = key_with_ts_and_value_formatter(batch_id, result)
+    return (key, from_reverse_timestamp(reverse_ts), value)
+
+
+def key_with_ts_only_formatter(batch_id, result):
+    key, timestamp, value = key_with_ts_and_value_formatter(batch_id, result)
+    return (key, timestamp)

--- a/vumi_message_store/riak_backend.py
+++ b/vumi_message_store/riak_backend.py
@@ -10,7 +10,7 @@ from twisted.internet.defer import returnValue
 from vumi.persist.model import Manager
 
 from vumi_message_store.models import (
-    from_reverse_timestamp,
+    from_reverse_timestamp, to_reverse_timestamp,
     Batch, CurrentTag, InboundMessage, OutboundMessage, Event)
 
 
@@ -253,8 +253,8 @@ class MessageStoreRiakBackend(object):
     def list_batch_inbound_keys_with_addresses(self, batch_id, start=None,
                                                end=None, max_results=None):
         """
-        List inbound message keys with timestamps and addresses for the given
-        batch.
+        List inbound message keys with timestamps and addresses in ascending
+        timestamp order for the given batch.
         """
         if max_results is None:
             max_results = self.DEFAULT_MAX_RESULTS
@@ -269,8 +269,8 @@ class MessageStoreRiakBackend(object):
     def list_batch_outbound_keys_with_addresses(self, batch_id, start=None,
                                                 end=None, max_results=None):
         """
-        List outbound message keys with timestamps and addresses for the given
-        batch.
+        List outbound message keys with timestamps and addresses in ascending
+        timestamp order for the given batch.
         """
         if max_results is None:
             max_results = self.DEFAULT_MAX_RESULTS
@@ -280,6 +280,48 @@ class MessageStoreRiakBackend(object):
             return_terms=True, max_results=max_results)
         returnValue(IndexPageWrapper(
             key_with_ts_and_value_formatter, self, batch_id, results))
+
+    @Manager.calls_manager
+    def list_batch_inbound_keys_with_addresses_reverse(self, batch_id,
+                                                       start=None, end=None,
+                                                       max_results=None):
+        """
+        List inbound message keys with timestamps and addresses in descending
+        timestamp order for the given batch.
+        """
+        if start is not None:
+            start = to_reverse_timestamp(start)
+        if end is not None:
+            end = to_reverse_timestamp(end)
+        if max_results is None:
+            max_results = self.DEFAULT_MAX_RESULTS
+        start_value, end_value = self._start_end_values(batch_id, start, end)
+        results = yield self.inbound_messages.index_keys_page(
+            'batches_with_addresses_reverse', start_value, end_value,
+            return_terms=True, max_results=max_results)
+        returnValue(IndexPageWrapper(
+            key_with_rts_and_value_formatter, self, batch_id, results))
+
+    @Manager.calls_manager
+    def list_batch_outbound_keys_with_addresses_reverse(self, batch_id,
+                                                        start=None, end=None,
+                                                        max_results=None):
+        """
+        List outbound message keys with timestamps and addresses in descending
+        timestamp order for the given batch.
+        """
+        if start is not None:
+            start = to_reverse_timestamp(start)
+        if end is not None:
+            end = to_reverse_timestamp(end)
+        if max_results is None:
+            max_results = self.DEFAULT_MAX_RESULTS
+        start_value, end_value = self._start_end_values(batch_id, start, end)
+        results = yield self.outbound_messages.index_keys_page(
+            'batches_with_addresses_reverse', start_value, end_value,
+            return_terms=True, max_results=max_results)
+        returnValue(IndexPageWrapper(
+            key_with_rts_and_value_formatter, self, batch_id, results))
 
     @Manager.calls_manager
     def list_message_event_keys_with_statuses(self, message_id,

--- a/vumi_message_store/tests/helpers.py
+++ b/vumi_message_store/tests/helpers.py
@@ -1,0 +1,85 @@
+from datetime import datetime, timedelta
+
+from twisted.internet.defer import inlineCallbacks, returnValue
+from zope.interface import implements
+
+from vumi.tests.helpers import IHelper
+from vumi.message import format_vumi_date
+
+
+class MessageSequenceHelper(object):
+    implements(IHelper)
+
+    def __init__(self, backend, msg_helper):
+        self._backend = backend
+        self._msg_helper = msg_helper
+
+    def setup(self, *args, **kwargs):
+        pass
+
+    def cleanup(self):
+        pass
+
+    @inlineCallbacks
+    def create_inbound_message_sequence(self, msg_count=5, delay_seconds=1):
+        """
+        Generate a sequence of inbound messages in a new batch and add them to
+        the backend.
+
+        :param msg_count:
+            The number of messages to create
+        :param delay_seconds:
+            The delay in seconds between the timestamps of sequential messages
+
+        :returns:
+            The batch id of the new batch and a list of tuples describing each
+            message in the form (key, timestamp, address)
+        """
+        batch_id = yield self._backend.batch_start()
+        all_keys = []
+        start = (datetime.utcnow().replace(microsecond=0) -
+                 timedelta(seconds=msg_count * delay_seconds))
+        for i in xrange(msg_count):
+            timestamp = start + timedelta(seconds=i * delay_seconds)
+            addr = "addr%s" % (i,)
+            msg = self._msg_helper.make_inbound(
+                "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
+            yield self._backend.add_inbound_message(msg, batch_ids=[batch_id])
+
+            all_keys.append((msg["message_id"],            # Key
+                             format_vumi_date(timestamp),  # Timestamp
+                             addr))                        # Address
+
+        returnValue((batch_id, all_keys))
+
+    @inlineCallbacks
+    def create_outbound_message_sequence(self, msg_count=5, delay_seconds=1):
+        """
+        Generate a sequence of outbound messages in a new batch and add them to
+        the backend.
+
+        :param msg_count:
+            The number of messages to create
+        :param delay_seconds:
+            The delay in seconds between the timestamps of sequential messages
+
+        :returns:
+            The batch id of the new batch and a list of tuples describing each
+            message in the form (key, timestamp, address)
+        """
+        batch_id = yield self._backend.batch_start()
+        all_keys = []
+        start = (datetime.utcnow().replace(microsecond=0) -
+                 timedelta(seconds=msg_count * delay_seconds))
+        for i in xrange(msg_count):
+            timestamp = start + timedelta(seconds=i * delay_seconds)
+            addr = "addr%s" % (i,)
+            msg = self._msg_helper.make_inbound(
+                "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
+            yield self._backend.add_outbound_message(msg, batch_ids=[batch_id])
+
+            all_keys.append((msg["message_id"],            # Key
+                             format_vumi_date(timestamp),  # Timestamp
+                             addr))                        # Address
+
+        returnValue((batch_id, all_keys))

--- a/vumi_message_store/tests/helpers.py
+++ b/vumi_message_store/tests/helpers.py
@@ -1,14 +1,14 @@
 from datetime import datetime, timedelta
 
 from twisted.internet.defer import inlineCallbacks, returnValue
-from zope.interface import implements
+from zope.interface import implementer
 
 from vumi.tests.helpers import IHelper
 from vumi.message import format_vumi_date
 
 
+@implementer(IHelper)
 class MessageSequenceHelper(object):
-    implements(IHelper)
 
     def __init__(self, backend, msg_helper):
         self._backend = backend

--- a/vumi_message_store/tests/old_models.py
+++ b/vumi_message_store/tests/old_models.py
@@ -1,12 +1,15 @@
 """Previous versions of message store models."""
 
+from calendar import timegm
+from datetime import datetime
 
-from vumi.message import TransportUserMessage, TransportEvent
+from vumi.message import (
+    TransportUserMessage, TransportEvent, format_vumi_date, parse_vumi_date)
 from vumi.persist.model import Model
 from vumi.persist.fields import (
     VumiMessage, ForeignKey, ListOf, Dynamic, Tag, Unicode, ManyToMany)
 from vumi_message_store.migrators import (
-    InboundMessageMigrator, OutboundMessageMigrator)
+    InboundMessageMigrator, OutboundMessageMigrator, EventMigrator)
 
 
 class BatchVNone(Model):
@@ -107,3 +110,174 @@ class InboundMessageV2(Model):
             batches_with_timestamps.append(u"%s$%s" % (batch_id, timestamp))
         self.batches_with_timestamps = batches_with_timestamps
         return super(InboundMessageV2, self).save()
+
+
+class OutboundMessageV3(Model):
+    bucket = 'outboundmessage'
+
+    VERSION = 3
+    MIGRATOR = OutboundMessageMigrator
+
+    # key is message_id
+    msg = VumiMessage(TransportUserMessage)
+    batches = ManyToMany(BatchVNone)
+
+    # Extra fields for compound indexes
+    batches_with_timestamps = ListOf(Unicode(), index=True)
+    batches_with_addresses = ListOf(Unicode(), index=True)
+
+    def save(self):
+        # We override this method to set our index fields before saving.
+        batches_with_timestamps = []
+        batches_with_addresses = []
+        timestamp = format_vumi_date(self.msg['timestamp'])
+        for batch_id in self.batches.keys():
+            batches_with_timestamps.append(u"%s$%s" % (batch_id, timestamp))
+            batches_with_addresses.append(
+                u"%s$%s$%s" % (batch_id, timestamp, self.msg['to_addr']))
+        self.batches_with_timestamps = batches_with_timestamps
+        self.batches_with_addresses = batches_with_addresses
+        return super(OutboundMessageV3, self).save()
+
+
+class InboundMessageV3(Model):
+    bucket = 'inboundmessage'
+
+    VERSION = 3
+    MIGRATOR = InboundMessageMigrator
+
+    # key is message_id
+    msg = VumiMessage(TransportUserMessage)
+    batches = ManyToMany(BatchVNone)
+
+    # Extra fields for compound indexes
+    batches_with_timestamps = ListOf(Unicode(), index=True)
+    batches_with_addresses = ListOf(Unicode(), index=True)
+
+    def save(self):
+        # We override this method to set our index fields before saving.
+        batches_with_timestamps = []
+        batches_with_addresses = []
+        timestamp = self.msg['timestamp']
+        for batch_id in self.batches.keys():
+            batches_with_timestamps.append(u"%s$%s" % (batch_id, timestamp))
+            batches_with_addresses.append(
+                u"%s$%s$%s" % (batch_id, timestamp, self.msg['from_addr']))
+        self.batches_with_timestamps = batches_with_timestamps
+        self.batches_with_addresses = batches_with_addresses
+        return super(InboundMessageV3, self).save()
+
+
+class EventV1(Model):
+    bucket = 'event'
+
+    VERSION = 1
+    MIGRATOR = EventMigrator
+
+    # key is event_id
+    event = VumiMessage(TransportEvent)
+    message = ForeignKey(OutboundMessageV3)
+
+    # Extra fields for compound indexes
+    message_with_status = Unicode(index=True, null=True)
+
+    def save(self):
+        # We override this method to set our index fields before saving.
+        timestamp = self.event['timestamp']
+        status = self.event['event_type']
+        if status == "delivery_report":
+            status = "%s.%s" % (status, self.event['delivery_status'])
+        self.message_with_status = u"%s$%s$%s" % (
+            self.message.key, timestamp, status)
+        return super(EventV1, self).save()
+
+
+def to_reverse_timestamp(vumi_timestamp):
+    """
+    Turn a vumi_date-formatted string into a string that sorts in reverse order
+    and can be turned back into a timestamp later.
+
+    This is done by converting to a unix timestamp and subtracting it from
+    0xffffffffff (2**40 - 1) to get a number well outside the range
+    representable by the datetime module. The result is returned as a
+    hexadecimal string.
+    """
+    timestamp = timegm(parse_vumi_date(vumi_timestamp).timetuple())
+    return "%X" % (0xffffffffff - timestamp)
+
+
+def from_reverse_timestamp(reverse_timestamp):
+    """
+    Turn a reverse timestamp string (from `to_reverse_timestamp()`) into a
+    vumi_date-formatted string.
+    """
+    timestamp = 0xffffffffff - int(reverse_timestamp, 16)
+    return format_vumi_date(datetime.utcfromtimestamp(timestamp))
+
+
+class OutboundMessageV4(Model):
+    bucket = 'outboundmessage'
+
+    VERSION = 4
+    MIGRATOR = OutboundMessageMigrator
+
+    # key is message_id
+    msg = VumiMessage(TransportUserMessage)
+    batches = ManyToMany(BatchVNone)
+
+    # Extra fields for compound indexes
+    batches_with_timestamps = ListOf(Unicode(), index=True)
+    batches_with_addresses = ListOf(Unicode(), index=True)
+    batches_with_addresses_reverse = ListOf(Unicode(), index=True)
+
+    def save(self):
+        # We override this method to set our index fields before saving.
+        self.batches_with_timestamps = []
+        self.batches_with_addresses = []
+        self.batches_with_addresses_reverse = []
+        timestamp = self.msg['timestamp']
+        if not isinstance(timestamp, basestring):
+            timestamp = format_vumi_date(timestamp)
+        reverse_ts = to_reverse_timestamp(timestamp)
+        for batch_id in self.batches.keys():
+            self.batches_with_timestamps.append(
+                u"%s$%s" % (batch_id, timestamp))
+            self.batches_with_addresses.append(
+                u"%s$%s$%s" % (batch_id, timestamp, self.msg['to_addr']))
+            self.batches_with_addresses_reverse.append(
+                u"%s$%s$%s" % (batch_id, reverse_ts, self.msg['to_addr']))
+        return super(OutboundMessageV4, self).save()
+
+
+class InboundMessageV4(Model):
+    bucket = 'inboundmessage'
+
+    VERSION = 4
+    MIGRATOR = InboundMessageMigrator
+
+    # key is message_id
+    msg = VumiMessage(TransportUserMessage)
+    batches = ManyToMany(BatchVNone)
+
+    # Extra fields for compound indexes
+    batches_with_timestamps = ListOf(Unicode(), index=True)
+    batches_with_addresses = ListOf(Unicode(), index=True)
+    batches_with_addresses_reverse = ListOf(Unicode(), index=True)
+
+    def save(self):
+        # We override this method to set our index fields before saving.
+        self.batches_with_timestamps = []
+        self.batches_with_addresses = []
+        self.batches_with_addresses_reverse = []
+        timestamp = self.msg['timestamp']
+        if not isinstance(timestamp, basestring):
+            timestamp = format_vumi_date(timestamp)
+        reverse_ts = to_reverse_timestamp(timestamp)
+        for batch_id in self.batches.keys():
+            self.batches_with_timestamps.append(
+                u"%s$%s" % (batch_id, timestamp))
+            self.batches_with_addresses.append(
+                u"%s$%s$%s" % (batch_id, timestamp, self.msg['from_addr']))
+            self.batches_with_addresses_reverse.append(
+                u"%s$%s$%s" % (batch_id, reverse_ts, self.msg['from_addr']))
+        return super(InboundMessageV4, self).save()

--- a/vumi_message_store/tests/test_memory_backend_manager.py
+++ b/vumi_message_store/tests/test_memory_backend_manager.py
@@ -35,4 +35,4 @@ class TestFakeRiakState(VumiTestCase):
         # Assert that the first object has been removed from the index
         index = bucket["indexes"]["index_key"]
         object1_index_values = [(v, k) for v, k in index if k == object1.key]
-        self.assertFalse(any(object1_index_values))
+        self.assertEqual(object1_index_values, [])

--- a/vumi_message_store/tests/test_memory_backend_manager.py
+++ b/vumi_message_store/tests/test_memory_backend_manager.py
@@ -1,0 +1,34 @@
+"""
+Tests for vumi_message_store.memory_backend_manager.
+"""
+from vumi.tests.helpers import VumiTestCase
+from vumi_message_store.memory_backend_manager import (
+    FakeRiakState, FakeRiakObject)
+
+
+class TestFakeRiakState(VumiTestCase):
+
+    def setUp(self):
+        self.state = FakeRiakState(is_sync=False)
+        self.add_cleanup(self.state.teardown)
+
+    def test_old_objects_removed_from_indexes(self):
+        bucket = self.state._get_bucket("bucket")
+
+        # Add two objects with "index_key" index values
+        fake_object1 = FakeRiakObject(self.state, "bucket", "mykey")
+        fake_object2 = FakeRiakObject(self.state, "bucket", "mykey2")
+        fake_object1.add_index("index_key", "index_value")
+        fake_object2.add_index("index_key", "index_value2")
+        self.state.store_object(fake_object1)
+        self.state.store_object(fake_object2)
+
+        # Remove the index value for the first object and store it again
+        fake_object1.remove_index("index_key")
+        fake_object1.add_index("newkey", "newvalue")
+        self.state.store_object(fake_object1)
+
+        # Assert that the first object has been removed from the index
+        index = bucket["indexes"]["index_key"]
+        is_object1_key = lambda (_, key): key == fake_object1.key
+        self.assertFalse(any(filter(is_object1_key, index)))

--- a/vumi_message_store/tests/test_message_store.py
+++ b/vumi_message_store/tests/test_message_store.py
@@ -4,7 +4,7 @@ Tests for vumi_message_store.message_store.
 from datetime import datetime, timedelta
 
 from twisted.internet.defer import inlineCallbacks
-from vumi.message import VUMI_DATE_FORMAT
+from vumi.message import format_vumi_date
 from vumi.tests.helpers import VumiTestCase, MessageHelper, PersistenceHelper
 from zope.interface.verify import verifyObject
 
@@ -13,13 +13,6 @@ from vumi_message_store.interfaces import (
     IMessageStoreBatchManager, IOperationalMessageStore, IQueryMessageStore)
 from vumi_message_store.message_store import (
     MessageStoreBatchManager, OperationalMessageStore, QueryMessageStore)
-
-
-def vumi_date(timestamp):
-    """
-    Turn a datetime object into a VUMI_DATE_FORMAT string.
-    """
-    return datetime.strftime(timestamp, VUMI_DATE_FORMAT)
 
 
 # TODO: Better way to test indexes. Currently indexes are retrieved
@@ -741,7 +734,7 @@ class TestQueryMessageStore(VumiTestCase):
             msg = self.msg_helper.make_inbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.store.list_batch_inbound_keys_with_timestamps(
             batch_id, max_results=3)
@@ -765,7 +758,7 @@ class TestQueryMessageStore(VumiTestCase):
             msg = self.msg_helper.make_inbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.store.list_batch_inbound_keys_with_timestamps(
             batch_id, start=all_keys[1][1], max_results=3)
@@ -789,7 +782,7 @@ class TestQueryMessageStore(VumiTestCase):
             msg = self.msg_helper.make_inbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.store.list_batch_inbound_keys_with_timestamps(
             batch_id, end=all_keys[-2][1], max_results=3)
@@ -813,7 +806,7 @@ class TestQueryMessageStore(VumiTestCase):
             msg = self.msg_helper.make_inbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.store.list_batch_inbound_keys_with_timestamps(
             batch_id, start=all_keys[1][1], end=all_keys[-2][1], max_results=2)
@@ -849,7 +842,7 @@ class TestQueryMessageStore(VumiTestCase):
             msg = self.msg_helper.make_outbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.store.list_batch_outbound_keys_with_timestamps(
             batch_id, max_results=3)
@@ -873,7 +866,7 @@ class TestQueryMessageStore(VumiTestCase):
             msg = self.msg_helper.make_outbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.store.list_batch_outbound_keys_with_timestamps(
             batch_id, start=all_keys[1][1], max_results=3)
@@ -897,7 +890,7 @@ class TestQueryMessageStore(VumiTestCase):
             msg = self.msg_helper.make_outbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.store.list_batch_outbound_keys_with_timestamps(
             batch_id, end=all_keys[-2][1], max_results=3)
@@ -921,7 +914,7 @@ class TestQueryMessageStore(VumiTestCase):
             msg = self.msg_helper.make_outbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.store.list_batch_outbound_keys_with_timestamps(
             batch_id, start=all_keys[1][1], end=all_keys[-2][1], max_results=2)
@@ -959,7 +952,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.store.list_batch_inbound_keys_with_addresses(
             batch_id, max_results=3)
@@ -985,7 +978,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.store.list_batch_inbound_keys_with_addresses(
             batch_id, start=all_keys[1][1], max_results=3)
@@ -1011,7 +1004,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.store.list_batch_inbound_keys_with_addresses(
             batch_id, end=all_keys[-2][1], max_results=3)
@@ -1037,7 +1030,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.store.list_batch_inbound_keys_with_addresses(
             batch_id, start=all_keys[1][1], end=all_keys[-2][1], max_results=2)
@@ -1075,7 +1068,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.store.list_batch_outbound_keys_with_addresses(
             batch_id, max_results=3)
@@ -1101,7 +1094,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.store.list_batch_outbound_keys_with_addresses(
             batch_id, start=all_keys[1][1], max_results=3)
@@ -1127,7 +1120,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.store.list_batch_outbound_keys_with_addresses(
             batch_id, end=all_keys[-2][1], max_results=3)
@@ -1153,7 +1146,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.store.list_batch_outbound_keys_with_addresses(
             batch_id, start=all_keys[1][1], end=all_keys[-2][1], max_results=2)
@@ -1192,7 +1185,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = (
             yield self.store.list_batch_inbound_keys_with_addresses_reverse(
@@ -1220,7 +1213,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = (
             yield self.store.list_batch_inbound_keys_with_addresses_reverse(
@@ -1248,7 +1241,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = (
             yield self.store.list_batch_inbound_keys_with_addresses_reverse(
@@ -1276,7 +1269,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = (
             yield self.store.list_batch_inbound_keys_with_addresses_reverse(
@@ -1318,7 +1311,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = (
             yield self.store.list_batch_outbound_keys_with_addresses_reverse(
@@ -1346,7 +1339,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = (
             yield self.store.list_batch_outbound_keys_with_addresses_reverse(
@@ -1374,7 +1367,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = (
             yield self.store.list_batch_outbound_keys_with_addresses_reverse(
@@ -1402,7 +1395,7 @@ class TestQueryMessageStore(VumiTestCase):
                 "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = (
             yield self.store.list_batch_outbound_keys_with_addresses_reverse(
@@ -1449,11 +1442,12 @@ class TestQueryMessageStore(VumiTestCase):
             self.msg_helper.make_delivery_report(
                 msg, timestamp=(start + timedelta(seconds=4))),
         ]
-        all_keys = [(ack["event_id"], vumi_date(ack["timestamp"]), "ack")]
+        all_keys = [
+            (ack["event_id"], format_vumi_date(ack["timestamp"]), "ack")]
         for dr in drs:
             yield self.backend.add_event(dr)
             all_keys.append(
-                (dr["event_id"], vumi_date(dr["timestamp"]),
+                (dr["event_id"], format_vumi_date(dr["timestamp"]),
                  "delivery_report.delivered"))
 
         keys_p1 = yield self.store.list_message_event_keys_with_statuses(

--- a/vumi_message_store/tests/test_message_store.py
+++ b/vumi_message_store/tests/test_message_store.py
@@ -247,15 +247,6 @@ class TestOperationalMessageStore(VumiTestCase):
         batch_keys = yield self.bi_cache.list_inbound_message_keys("mybatch")
         self.assertEqual(set(batch_keys), set([msg["message_id"]]))
 
-        # Make sure we're writing the right indexes.
-        self.assertEqual(stored_msg._riak_object.get_indexes(), set([
-            ('batches_bin', "mybatch"),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("mybatch", msg['timestamp'])),
-            ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("mybatch", msg['timestamp'], msg['from_addr'])),
-        ]))
-
     @inlineCallbacks
     def test_add_inbound_message_with_multiple_batch_ids(self):
         """
@@ -278,20 +269,6 @@ class TestOperationalMessageStore(VumiTestCase):
         yourkeys = yield self.bi_cache.list_inbound_message_keys("yourbatch")
         self.assertEqual(yourkeys, [msg["message_id"]])
 
-        # Make sure we're writing the right indexes.
-        self.assertEqual(stored_msg._riak_object.get_indexes(), set([
-            ('batches_bin', "mybatch"),
-            ('batches_bin', "yourbatch"),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("mybatch", msg['timestamp'])),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("yourbatch", msg['timestamp'])),
-            ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("mybatch", msg['timestamp'], msg['from_addr'])),
-            ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("yourbatch", msg['timestamp'], msg['from_addr'])),
-        ]))
-
     @inlineCallbacks
     def test_add_inbound_message_to_new_batch(self):
         """
@@ -312,20 +289,6 @@ class TestOperationalMessageStore(VumiTestCase):
         self.assertEqual(mykeys, [msg["message_id"]])
         yourkeys = yield self.bi_cache.list_inbound_message_keys("yourbatch")
         self.assertEqual(yourkeys, [msg["message_id"]])
-
-        # Make sure we're writing the right indexes.
-        self.assertEqual(stored_msg._riak_object.get_indexes(), set([
-            ('batches_bin', "mybatch"),
-            ('batches_bin', "yourbatch"),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("mybatch", msg['timestamp'])),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("yourbatch", msg['timestamp'])),
-            ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("mybatch", msg['timestamp'], msg['from_addr'])),
-            ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("yourbatch", msg['timestamp'], msg['from_addr'])),
-        ]))
 
     @inlineCallbacks
     def test_get_inbound_message(self):
@@ -398,15 +361,6 @@ class TestOperationalMessageStore(VumiTestCase):
         batch_keys = yield self.bi_cache.list_outbound_message_keys("mybatch")
         self.assertEqual(batch_keys, [msg["message_id"]])
 
-        # Make sure we're writing the right indexes.
-        self.assertEqual(stored_msg._riak_object.get_indexes(), set([
-            ('batches_bin', "mybatch"),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("mybatch", msg['timestamp'])),
-            ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("mybatch", msg['timestamp'], msg['to_addr'])),
-        ]))
-
     @inlineCallbacks
     def test_add_outbound_message_with_multiple_batch_ids(self):
         """
@@ -429,20 +383,6 @@ class TestOperationalMessageStore(VumiTestCase):
         yourkeys = yield self.bi_cache.list_outbound_message_keys("yourbatch")
         self.assertEqual(yourkeys, [msg["message_id"]])
 
-        # Make sure we're writing the right indexes.
-        self.assertEqual(stored_msg._riak_object.get_indexes(), set([
-            ('batches_bin', "mybatch"),
-            ('batches_bin', "yourbatch"),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("mybatch", msg['timestamp'])),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("yourbatch", msg['timestamp'])),
-            ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("mybatch", msg['timestamp'], msg['to_addr'])),
-            ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("yourbatch", msg['timestamp'], msg['to_addr'])),
-        ]))
-
     @inlineCallbacks
     def test_add_outbound_message_to_new_batch(self):
         """
@@ -463,20 +403,6 @@ class TestOperationalMessageStore(VumiTestCase):
         self.assertEqual(mykeys, [msg["message_id"]])
         yourkeys = yield self.bi_cache.list_outbound_message_keys("yourbatch")
         self.assertEqual(yourkeys, [msg["message_id"]])
-
-        # Make sure we're writing the right indexes.
-        self.assertEqual(stored_msg._riak_object.get_indexes(), set([
-            ('batches_bin', "mybatch"),
-            ('batches_bin', "yourbatch"),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("mybatch", msg['timestamp'])),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("yourbatch", msg['timestamp'])),
-            ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("mybatch", msg['timestamp'], msg['to_addr'])),
-            ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("yourbatch", msg['timestamp'], msg['to_addr'])),
-        ]))
 
     @inlineCallbacks
     def test_get_outbound_message(self):

--- a/vumi_message_store/tests/test_message_store.py
+++ b/vumi_message_store/tests/test_message_store.py
@@ -1175,6 +1175,258 @@ class TestQueryMessageStore(VumiTestCase):
         self.assertEqual(list(keys_page), [])
 
     @inlineCallbacks
+    def test_list_batch_inbound_keys_with_addresses_reverse(self):
+        """
+        When we ask for a list of inbound message keys with addresses, we get
+        an IndexPageWrapper containing the first page of results and can ask
+        for following pages until all results are delivered.
+        """
+        batch_id = yield self.backend.batch_start()
+        all_keys = []
+        start = (datetime.utcnow().replace(microsecond=0) +
+                 timedelta(seconds=10))
+        for i in xrange(5):
+            timestamp = start - timedelta(seconds=i)
+            addr = "addr%s" % (i,)
+            msg = self.msg_helper.make_inbound(
+                "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
+            yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
+            all_keys.append(
+                (msg["message_id"], vumi_date(timestamp), addr))
+
+        keys_p1 = (
+            yield self.store.list_batch_inbound_keys_with_addresses_reverse(
+                batch_id, max_results=3))
+        # Paginated results are sorted by timestamp.
+        self.assertEqual(list(keys_p1), all_keys[:3])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[3:])
+
+    @inlineCallbacks
+    def test_list_batch_inbound_keys_with_addresses_reverse_range_start(self):
+        """
+        When we ask for a list of inbound message keys with addresses, we can
+        specify a start timestamp.
+        """
+        batch_id = yield self.backend.batch_start()
+        all_keys = []
+        start = (datetime.utcnow().replace(microsecond=0) +
+                 timedelta(seconds=10))
+        for i in xrange(5):
+            timestamp = start - timedelta(seconds=i)
+            addr = "addr%s" % (i,)
+            msg = self.msg_helper.make_inbound(
+                "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
+            yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
+            all_keys.append(
+                (msg["message_id"], vumi_date(timestamp), addr))
+
+        keys_p1 = (
+            yield self.store.list_batch_inbound_keys_with_addresses_reverse(
+                batch_id, start=all_keys[1][1], max_results=3))
+        # Paginated results are sorted by timestamp.
+        self.assertEqual(list(keys_p1), all_keys[1:4])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[4:])
+
+    @inlineCallbacks
+    def test_list_batch_inbound_keys_with_addresses_reverse_range_end(self):
+        """
+        When we ask for a list of inbound message keys with addresses, we can
+        specify an end timestamp.
+        """
+        batch_id = yield self.backend.batch_start()
+        all_keys = []
+        start = (datetime.utcnow().replace(microsecond=0) +
+                 timedelta(seconds=10))
+        for i in xrange(5):
+            timestamp = start - timedelta(seconds=i)
+            addr = "addr%s" % (i,)
+            msg = self.msg_helper.make_inbound(
+                "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
+            yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
+            all_keys.append(
+                (msg["message_id"], vumi_date(timestamp), addr))
+
+        keys_p1 = (
+            yield self.store.list_batch_inbound_keys_with_addresses_reverse(
+                batch_id, end=all_keys[-2][1], max_results=3))
+        # Paginated results are sorted by timestamp.
+        self.assertEqual(list(keys_p1), all_keys[0:3])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[3:-1])
+
+    @inlineCallbacks
+    def test_list_batch_inbound_keys_with_addresses_reverse_range(self):
+        """
+        When we ask for a list of inbound message keys with addresses, we can
+        specify both ends of the range.
+        """
+        batch_id = yield self.backend.batch_start()
+        all_keys = []
+        start = (datetime.utcnow().replace(microsecond=0) +
+                 timedelta(seconds=10))
+        for i in xrange(5):
+            timestamp = start - timedelta(seconds=i)
+            addr = "addr%s" % (i,)
+            msg = self.msg_helper.make_inbound(
+                "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
+            yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
+            all_keys.append(
+                (msg["message_id"], vumi_date(timestamp), addr))
+
+        keys_p1 = (
+            yield self.store.list_batch_inbound_keys_with_addresses_reverse(
+                batch_id, start=all_keys[1][1], end=all_keys[-2][1],
+                max_results=2))
+        # Paginated results are sorted by timestamp.
+        self.assertEqual(list(keys_p1), all_keys[1:3])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[3:-1])
+
+    @inlineCallbacks
+    def test_list_batch_inbound_keys_with_addresses_reverse_empty(self):
+        """
+        When we ask for a list of inbound message keys with addresses for an
+        empty batch, we get an empty IndexPageWrapper.
+        """
+        batch_id = yield self.backend.batch_start()
+        keys_page = (
+            yield self.store.list_batch_inbound_keys_with_addresses_reverse(
+                batch_id))
+        self.assertEqual(list(keys_page), [])
+
+    @inlineCallbacks
+    def test_list_batch_outbound_keys_with_addresses_reverse(self):
+        """
+        When we ask for a list of outbound message keys with addresses, we get
+        an IndexPageWrapper containing the first page of results and can ask
+        for following pages until all results are delivered.
+        """
+        batch_id = yield self.backend.batch_start()
+        all_keys = []
+        start = (datetime.utcnow().replace(microsecond=0) +
+                 timedelta(seconds=10))
+        for i in xrange(5):
+            timestamp = start - timedelta(seconds=i)
+            addr = "addr%s" % (i,)
+            msg = self.msg_helper.make_outbound(
+                "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
+            yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
+            all_keys.append(
+                (msg["message_id"], vumi_date(timestamp), addr))
+
+        keys_p1 = (
+            yield self.store.list_batch_outbound_keys_with_addresses_reverse(
+                batch_id, max_results=3))
+        # Paginated results are sorted by timestamp.
+        self.assertEqual(list(keys_p1), all_keys[:3])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[3:])
+
+    @inlineCallbacks
+    def test_list_batch_outbound_keys_with_addresses_reverse_range_start(self):
+        """
+        When we ask for a list of outbound message keys with addresses, we can
+        specify a start timestamp.
+        """
+        batch_id = yield self.backend.batch_start()
+        all_keys = []
+        start = (datetime.utcnow().replace(microsecond=0) +
+                 timedelta(seconds=10))
+        for i in xrange(5):
+            timestamp = start - timedelta(seconds=i)
+            addr = "addr%s" % (i,)
+            msg = self.msg_helper.make_outbound(
+                "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
+            yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
+            all_keys.append(
+                (msg["message_id"], vumi_date(timestamp), addr))
+
+        keys_p1 = (
+            yield self.store.list_batch_outbound_keys_with_addresses_reverse(
+                batch_id, start=all_keys[1][1], max_results=3))
+        # Paginated results are sorted by timestamp.
+        self.assertEqual(list(keys_p1), all_keys[1:4])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[4:])
+
+    @inlineCallbacks
+    def test_list_batch_outbound_keys_with_addresses_reverse_range_end(self):
+        """
+        When we ask for a list of outbound message keys with addresses, we can
+        specify an end timestamp.
+        """
+        batch_id = yield self.backend.batch_start()
+        all_keys = []
+        start = (datetime.utcnow().replace(microsecond=0) +
+                 timedelta(seconds=10))
+        for i in xrange(5):
+            timestamp = start - timedelta(seconds=i)
+            addr = "addr%s" % (i,)
+            msg = self.msg_helper.make_outbound(
+                "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
+            yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
+            all_keys.append(
+                (msg["message_id"], vumi_date(timestamp), addr))
+
+        keys_p1 = (
+            yield self.store.list_batch_outbound_keys_with_addresses_reverse(
+                batch_id, end=all_keys[-2][1], max_results=3))
+        # Paginated results are sorted by timestamp.
+        self.assertEqual(list(keys_p1), all_keys[0:3])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[3:-1])
+
+    @inlineCallbacks
+    def test_list_batch_outbound_keys_with_addresses_reverse_range(self):
+        """
+        When we ask for a list of outbound message keys with addresses, we can
+        specify both ends of the range.
+        """
+        batch_id = yield self.backend.batch_start()
+        all_keys = []
+        start = (datetime.utcnow().replace(microsecond=0) +
+                 timedelta(seconds=10))
+        for i in xrange(5):
+            timestamp = start - timedelta(seconds=i)
+            addr = "addr%s" % (i,)
+            msg = self.msg_helper.make_outbound(
+                "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
+            yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
+            all_keys.append(
+                (msg["message_id"], vumi_date(timestamp), addr))
+
+        keys_p1 = (
+            yield self.store.list_batch_outbound_keys_with_addresses_reverse(
+                batch_id, start=all_keys[1][1], end=all_keys[-2][1],
+                max_results=2))
+        # Paginated results are sorted by timestamp.
+        self.assertEqual(list(keys_p1), all_keys[1:3])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[3:-1])
+
+    @inlineCallbacks
+    def test_list_batch_outbound_keys_with_addresses_reverse_empty(self):
+        """
+        When we ask for a list of outbound message keys with addresses for an
+        empty batch, we get an empty IndexPageWrapper.
+        """
+        batch_id = yield self.backend.batch_start()
+        keys_page = (
+            yield self.store.list_batch_outbound_keys_with_addresses_reverse(
+                batch_id))
+        self.assertEqual(list(keys_page), [])
+
+    @inlineCallbacks
     def test_list_message_event_keys_with_statuses(self):
         """
         When we ask for a list of event keys with statuses, we get an

--- a/vumi_message_store/tests/test_migrators.py
+++ b/vumi_message_store/tests/test_migrators.py
@@ -2,23 +2,30 @@
 
 from twisted.internet.defer import inlineCallbacks
 
+from vumi.message import format_vumi_date
 from vumi.tests.helpers import VumiTestCase, MessageHelper, PersistenceHelper
 
 from vumi_message_store.tests.old_models import (
-    EventVNone, BatchVNone,
-    InboundMessageVNone, OutboundMessageVNone,
-    InboundMessageV1, OutboundMessageV1,
-    InboundMessageV2, OutboundMessageV2)
+    OutboundMessageVNone, InboundMessageVNone, EventVNone, BatchVNone,
+    OutboundMessageV1, InboundMessageV1, OutboundMessageV2,
+    InboundMessageV2, OutboundMessageV3, InboundMessageV3, EventV1,
+    OutboundMessageV4, InboundMessageV4)
 from vumi_message_store.memory_backend_manager import (
     FakeRiakState, FakeMemoryRiakManager)
 from vumi_message_store.models import (
-    InboundMessage as InboundMessageV3,
-    OutboundMessage as OutboundMessageV3,
-    Event as EventV1)
+    to_reverse_timestamp,
+    InboundMessage as InboundMessageV5,
+    OutboundMessage as OutboundMessageV5,
+    Event as EventV2)
 
 
 def mws_value(msg_id, event, status):
     return "%s$%s$%s" % (msg_id, event['timestamp'], status)
+
+
+def bwsr_value(batch_id, event, status):
+    reverse_ts = to_reverse_timestamp(format_vumi_date(event['timestamp']))
+    return "%s$%s$%s" % (batch_id, reverse_ts, status)
 
 
 def bwt_value(batch_id, msg):
@@ -33,6 +40,16 @@ def bwa_out_value(batch_id, msg):
     return "%s$%s$%s" % (batch_id, msg['timestamp'], msg['to_addr'])
 
 
+def bwar_in_value(batch_id, msg):
+    reverse_ts = to_reverse_timestamp(format_vumi_date(msg['timestamp']))
+    return "%s$%s$%s" % (batch_id, reverse_ts, msg['from_addr'])
+
+
+def bwar_out_value(batch_id, msg):
+    reverse_ts = to_reverse_timestamp(format_vumi_date(msg['timestamp']))
+    return "%s$%s$%s" % (batch_id, reverse_ts, msg['to_addr'])
+
+
 def batch_index(value):
     return ("batches_bin", value)
 
@@ -45,11 +62,16 @@ def bwa_index(value):
     return ("batches_with_addresses_bin", value)
 
 
+def bwar_index(value):
+    return ("batches_with_addresses_reverse_bin", value)
+
+
 class EventMigratorTestMixin(object):
 
     def set_up_proxies(self):
         self.event_vnone = self.manager.proxy(EventVNone)
         self.event_v1 = self.manager.proxy(EventV1)
+        self.event_v2 = self.manager.proxy(EventV2)
 
     @inlineCallbacks
     def test_migrate_vnone_to_v1(self):
@@ -140,6 +162,89 @@ class EventMigratorTestMixin(object):
             ("message_with_status_bin", mws_value(msg_id, event, "ack")),
         ]))
 
+    @inlineCallbacks
+    def test_migrate_v1_to_v2(self):
+        """
+        A v1 model can be migrated to v2, but the batches field will be empty.
+        """
+        msg = self.msg_helper.make_outbound("outbound")
+        msg_id = msg["message_id"]
+        event = self.msg_helper.make_ack(msg)
+        old_record = self.event_v1(
+            event["event_id"], event=event, message=msg_id)
+        yield old_record.save()
+
+        new_record = yield self.event_v2.load(old_record.key)
+        self.assertEqual(new_record.event, event)
+        self.assertEqual(new_record.message.key, msg_id)
+        self.assertEqual(new_record.batches.keys(), [])
+        self.assertEqual(new_record.message_with_status, None)
+        self.assertEqual(set(new_record.batches_with_statuses_reverse), set())
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            ("message_bin", msg_id),
+            ("message_with_status_bin", mws_value(msg_id, event, "ack")),
+        ]))
+
+        # Some indexes are only added at save time.
+        yield new_record.save()
+        self.assertEqual(
+            new_record.message_with_status, mws_value(msg_id, event, "ack"))
+        self.assertEqual(set(new_record.batches_with_statuses_reverse), set())
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            ("message_bin", msg_id),
+            ("message_with_status_bin", mws_value(msg_id, event, "ack")),
+        ]))
+
+    @inlineCallbacks
+    def test_reverse_migrate_v2_v1(self):
+        """
+        A v2 model can be stored in a v1-compatible way, but batch information
+        is preserved.
+        """
+        # Configure the manager to save the older message version.
+        modelcls = self.event_v2._modelcls
+        model_name = "%s.%s" % (modelcls.__module__, modelcls.__name__)
+        self.manager.store_versions[model_name] = 1
+
+        msg = self.msg_helper.make_outbound("outbound")
+        msg_id = msg["message_id"]
+        event = self.msg_helper.make_ack(msg)
+        new_record = self.event_v2(
+            event["event_id"], event=event, message=msg_id)
+        new_record.batches.add_key(u"batch-1")
+        yield new_record.save()
+
+        old_record = yield self.event_v1.load(new_record.key)
+        self.assertEqual(old_record.event, event)
+        self.assertEqual(old_record.message.key, msg_id)
+        self.assertEqual(new_record.message_with_status, None)
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            ("message_bin", msg_id),
+            ("batches_bin", "batch-1"),
+            ("message_with_status_bin", mws_value(msg_id, event, "ack")),
+            ("batches_with_statuses_reverse_bin",
+             bwsr_value("batch-1", event, "ack")),
+        ]))
+
+        # Some indexes are only added at save time.
+        yield old_record.save()
+        self.assertEqual(
+            old_record.message_with_status, mws_value(msg_id, event, "ack"))
+        self.assertEqual(old_record._riak_object.get_indexes(), set([
+            ("message_bin", msg_id),
+            ("batches_bin", "batch-1"),
+            ("message_with_status_bin", mws_value(msg_id, event, "ack")),
+            ("batches_with_statuses_reverse_bin",
+             bwsr_value("batch-1", event, "ack")),
+        ]))
+
+        new2_record = yield self.event_v2.load(old_record.key)
+        self.assertEqual(new2_record.event, event)
+        self.assertEqual(new2_record.message.key, msg_id)
+        self.assertEqual(new2_record.batches.keys(), [u"batch-1"])
+        self.assertEqual(new2_record.message_with_status, None)
+        self.assertEqual(set(new2_record.batches_with_statuses_reverse), set())
+
 
 class OutboundMessageMigratorTestMixin(object):
     def set_up_proxies(self):
@@ -147,6 +252,8 @@ class OutboundMessageMigratorTestMixin(object):
         self.outbound_v1 = self.manager.proxy(OutboundMessageV1)
         self.outbound_v2 = self.manager.proxy(OutboundMessageV2)
         self.outbound_v3 = self.manager.proxy(OutboundMessageV3)
+        self.outbound_v4 = self.manager.proxy(OutboundMessageV4)
+        self.outbound_v5 = self.manager.proxy(OutboundMessageV5)
         self.batch_vnone = self.manager.proxy(BatchVNone)
 
     @inlineCallbacks
@@ -347,6 +454,258 @@ class OutboundMessageMigratorTestMixin(object):
         self.assertEqual(old_record.msg, msg)
         self.assertEqual(old_record.batches.keys(), [batch_1.key, batch_2.key])
 
+    @inlineCallbacks
+    def test_migrate_v3_to_v4_no_batches(self):
+        """
+        A v3 model with no batches has no extra indexes when migrated to v4.
+        """
+        msg = self.msg_helper.make_outbound("outbound")
+        old_record = self.outbound_v3(msg["message_id"], msg=msg)
+        yield old_record.save()
+        new_record = yield self.outbound_v4.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(set(new_record.batches_with_timestamps), set([]))
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+        yield new_record.save()
+        self.assertEqual(set(new_record.batches_with_timestamps), set([]))
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+    @inlineCallbacks
+    def test_migrate_v3_to_v4_one_batch(self):
+        """
+        A v3 model with one batch gets one extra index when migrated to v4.
+        """
+        msg = self.msg_helper.make_outbound("outbound")
+        old_batch = self.batch_vnone(key=u"batch-1")
+        old_record = self.outbound_v3(msg["message_id"], msg=msg)
+        old_record.batches.add_key(old_batch.key)
+        yield old_record.save()
+        new_record = yield self.outbound_v4.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [old_batch.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwa_index(bwa_out_value("batch-1", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(
+            set(new_record.batches_with_timestamps),
+            set([bwt_value("batch-1", msg)]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses),
+            set([bwa_out_value("batch-1", msg)]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse),
+            set([bwar_out_value("batch-1", msg)]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwa_index(bwa_out_value("batch-1", msg)),
+            bwar_index(bwar_out_value("batch-1", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_migrate_v3_to_v4_two_batches(self):
+        """
+        A v3 model with two batches gets two extra indexes when migrated to v4.
+        """
+        msg = self.msg_helper.make_outbound("outbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        old_record = self.outbound_v3(msg["message_id"], msg=msg)
+        old_record.batches.add_key(batch_1.key)
+        old_record.batches.add_key(batch_2.key)
+        yield old_record.save()
+        new_record = yield self.outbound_v4.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [batch_1.key, batch_2.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwt_index(bwt_value("batch-2", msg)),
+            bwa_index(bwa_out_value("batch-1", msg)),
+            bwa_index(bwa_out_value("batch-2", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwt_index(bwt_value("batch-2", msg)),
+            bwa_index(bwa_out_value("batch-1", msg)),
+            bwa_index(bwa_out_value("batch-2", msg)),
+            bwar_index(bwar_out_value("batch-1", msg)),
+            bwar_index(bwar_out_value("batch-2", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_reverse_migrate_v4_to_v3(self):
+        """
+        A v4 model can be stored in a v3-compatible way.
+        """
+        # Configure the manager to save the older message version.
+        modelcls = self.outbound_v4._modelcls
+        model_name = "%s.%s" % (modelcls.__module__, modelcls.__name__)
+        self.manager.store_versions[model_name] = 3
+
+        msg = self.msg_helper.make_outbound("outbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        new_record = self.outbound_v4(msg["message_id"], msg=msg)
+        new_record.batches.add_key(batch_1.key)
+        new_record.batches.add_key(batch_2.key)
+        yield new_record.save()
+
+        old_record = yield self.outbound_v3.load(new_record.key)
+        self.assertEqual(old_record.msg, msg)
+        self.assertEqual(old_record.batches.keys(), [batch_1.key, batch_2.key])
+
+    @inlineCallbacks
+    def test_migrate_v4_to_v5_no_batches(self):
+        """
+        A v4 model with no batches has no fewer indexes when migrated to v5.
+        """
+        msg = self.msg_helper.make_outbound("outbound")
+        old_record = self.outbound_v4(msg["message_id"], msg=msg)
+        yield old_record.save()
+        new_record = yield self.outbound_v5.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+        yield new_record.save()
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+    @inlineCallbacks
+    def test_migrate_v4_to_v5_one_batch(self):
+        """
+        A v4 model with one batch gets one fewer index when migrated to v5.
+        """
+        msg = self.msg_helper.make_outbound("outbound")
+        old_batch = self.batch_vnone(key=u"batch-1")
+        old_record = self.outbound_v4(msg["message_id"], msg=msg)
+        old_record.batches.add_key(old_batch.key)
+        yield old_record.save()
+        new_record = yield self.outbound_v5.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [old_batch.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwa_index(bwa_out_value("batch-1", msg)),
+            bwar_index(bwar_out_value("batch-1", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(
+            set(new_record.batches_with_addresses),
+            set([bwa_out_value("batch-1", msg)]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse),
+            set([bwar_out_value("batch-1", msg)]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwa_index(bwa_out_value("batch-1", msg)),
+            bwar_index(bwar_out_value("batch-1", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_migrate_v4_to_v5_two_batches(self):
+        """
+        A v4 model with two batches gets two fewer indexes when migrated to v5.
+        """
+        msg = self.msg_helper.make_outbound("outbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        old_record = self.outbound_v4(msg["message_id"], msg=msg)
+        old_record.batches.add_key(batch_1.key)
+        old_record.batches.add_key(batch_2.key)
+        yield old_record.save()
+        new_record = yield self.outbound_v5.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [batch_1.key, batch_2.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwa_index(bwa_out_value("batch-1", msg)),
+            bwa_index(bwa_out_value("batch-2", msg)),
+            bwar_index(bwar_out_value("batch-1", msg)),
+            bwar_index(bwar_out_value("batch-2", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwa_index(bwa_out_value("batch-1", msg)),
+            bwa_index(bwa_out_value("batch-2", msg)),
+            bwar_index(bwar_out_value("batch-1", msg)),
+            bwar_index(bwar_out_value("batch-2", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_reverse_migrate_v5_to_v4(self):
+        """
+        A v5 model can be stored in a v4-compatible way.
+        """
+        # Configure the manager to save the older message version.
+        modelcls = self.outbound_v5._modelcls
+        model_name = "%s.%s" % (modelcls.__module__, modelcls.__name__)
+        self.manager.store_versions[model_name] = 4
+
+        msg = self.msg_helper.make_outbound("outbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        new_record = self.outbound_v5(msg["message_id"], msg=msg)
+        new_record.batches.add_key(batch_1.key)
+        new_record.batches.add_key(batch_2.key)
+        yield new_record.save()
+
+        old_record = yield self.outbound_v4.load(new_record.key)
+        self.assertEqual(old_record.msg, msg)
+        self.assertEqual(old_record.batches.keys(), [batch_1.key, batch_2.key])
+
 
 class InboundMessageMigratorTestMixin(object):
 
@@ -355,6 +714,8 @@ class InboundMessageMigratorTestMixin(object):
         self.inbound_v1 = self.manager.proxy(InboundMessageV1)
         self.inbound_v2 = self.manager.proxy(InboundMessageV2)
         self.inbound_v3 = self.manager.proxy(InboundMessageV3)
+        self.inbound_v4 = self.manager.proxy(InboundMessageV4)
+        self.inbound_v5 = self.manager.proxy(InboundMessageV5)
         self.batch_vnone = self.manager.proxy(BatchVNone)
 
     @inlineCallbacks
@@ -552,6 +913,258 @@ class InboundMessageMigratorTestMixin(object):
         yield new_record.save()
 
         old_record = yield self.inbound_v2.load(new_record.key)
+        self.assertEqual(old_record.msg, msg)
+        self.assertEqual(old_record.batches.keys(), [batch_1.key, batch_2.key])
+
+    @inlineCallbacks
+    def test_migrate_v3_to_v4_no_batches(self):
+        """
+        A v3 model with no batches gets no extra indexes when migrated to v4.
+        """
+        msg = self.msg_helper.make_inbound("inbound")
+        old_record = self.inbound_v3(msg["message_id"], msg=msg)
+        yield old_record.save()
+        new_record = yield self.inbound_v4.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(set(new_record.batches_with_timestamps), set([]))
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+        yield new_record.save()
+        self.assertEqual(set(new_record.batches_with_timestamps), set([]))
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+    @inlineCallbacks
+    def test_migrate_v3_to_v4_one_batch(self):
+        """
+        A v3 model with one batche gets one extra index when migrated to v4.
+        """
+        msg = self.msg_helper.make_inbound("inbound")
+        old_batch = self.batch_vnone(key=u"batch-1")
+        old_record = self.inbound_v3(msg["message_id"], msg=msg)
+        old_record.batches.add_key(old_batch.key)
+        yield old_record.save()
+        new_record = yield self.inbound_v4.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [old_batch.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwa_index(bwa_in_value("batch-1", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(
+            set(new_record.batches_with_timestamps),
+            set([bwt_value("batch-1", msg)]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses),
+            set([bwa_in_value("batch-1", msg)]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse),
+            set([bwar_in_value("batch-1", msg)]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwa_index(bwa_in_value("batch-1", msg)),
+            bwar_index(bwar_in_value("batch-1", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_migrate_v3_to_v4_two_batches(self):
+        """
+        A v3 model with two batches gets two extra indexes when migrated to v4.
+        """
+        msg = self.msg_helper.make_inbound("inbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        old_record = self.inbound_v3(msg["message_id"], msg=msg)
+        old_record.batches.add_key(batch_1.key)
+        old_record.batches.add_key(batch_2.key)
+        yield old_record.save()
+        new_record = yield self.inbound_v4.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [batch_1.key, batch_2.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwt_index(bwt_value("batch-2", msg)),
+            bwa_index(bwa_in_value("batch-1", msg)),
+            bwa_index(bwa_in_value("batch-2", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwt_index(bwt_value("batch-1", msg)),
+            bwt_index(bwt_value("batch-2", msg)),
+            bwa_index(bwa_in_value("batch-1", msg)),
+            bwa_index(bwa_in_value("batch-2", msg)),
+            bwar_index(bwar_in_value("batch-1", msg)),
+            bwar_index(bwar_in_value("batch-2", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_reverse_migrate_v4_to_v3(self):
+        """
+        A v4 model can be stored in a v3-compatible way.
+        """
+        # Configure the manager to save the older message version.
+        modelcls = self.inbound_v4._modelcls
+        model_name = "%s.%s" % (modelcls.__module__, modelcls.__name__)
+        self.manager.store_versions[model_name] = 3
+
+        msg = self.msg_helper.make_inbound("inbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        new_record = self.inbound_v4(msg["message_id"], msg=msg)
+        new_record.batches.add_key(batch_1.key)
+        new_record.batches.add_key(batch_2.key)
+        yield new_record.save()
+
+        old_record = yield self.inbound_v3.load(new_record.key)
+        self.assertEqual(old_record.msg, msg)
+        self.assertEqual(old_record.batches.keys(), [batch_1.key, batch_2.key])
+
+    @inlineCallbacks
+    def test_migrate_v4_to_v5_no_batches(self):
+        """
+        A v4 model with no batches gets no fewer indexes when migrated to v5.
+        """
+        msg = self.msg_helper.make_inbound("inbound")
+        old_record = self.inbound_v4(msg["message_id"], msg=msg)
+        yield old_record.save()
+        new_record = yield self.inbound_v5.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+        yield new_record.save()
+        self.assertEqual(set(new_record.batches_with_addresses), set([]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([]))
+
+    @inlineCallbacks
+    def test_migrate_v4_to_v5_one_batch(self):
+        """
+        A v4 model with one batch gets one fewer index when migrated to v5.
+        """
+        msg = self.msg_helper.make_inbound("inbound")
+        old_batch = self.batch_vnone(key=u"batch-1")
+        old_record = self.inbound_v4(msg["message_id"], msg=msg)
+        old_record.batches.add_key(old_batch.key)
+        yield old_record.save()
+        new_record = yield self.inbound_v5.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [old_batch.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse), set([]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwa_index(bwa_in_value("batch-1", msg)),
+            bwar_index(bwar_in_value("batch-1", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(
+            set(new_record.batches_with_addresses),
+            set([bwa_in_value("batch-1", msg)]))
+        self.assertEqual(
+            set(new_record.batches_with_addresses_reverse),
+            set([bwar_in_value("batch-1", msg)]))
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            bwa_index(bwa_in_value("batch-1", msg)),
+            bwar_index(bwar_in_value("batch-1", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_migrate_v4_to_v5_two_batches(self):
+        """
+        A v4 model with two batches gets two fewer indexes when migrated to v5.
+        """
+        msg = self.msg_helper.make_inbound("inbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        old_record = self.inbound_v4(msg["message_id"], msg=msg)
+        old_record.batches.add_key(batch_1.key)
+        old_record.batches.add_key(batch_2.key)
+        yield old_record.save()
+        new_record = yield self.inbound_v5.load(old_record.key)
+        self.assertEqual(new_record.msg, msg)
+        self.assertEqual(new_record.batches.keys(), [batch_1.key, batch_2.key])
+
+        # The migration doesn't set the new fields and indexes, that only
+        # happens at save time.
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwa_index(bwa_in_value("batch-1", msg)),
+            bwa_index(bwa_in_value("batch-2", msg)),
+            bwar_index(bwar_in_value("batch-1", msg)),
+            bwar_index(bwar_in_value("batch-2", msg)),
+        ]))
+
+        yield new_record.save()
+        self.assertEqual(new_record._riak_object.get_indexes(), set([
+            batch_index("batch-1"),
+            batch_index("batch-2"),
+            bwa_index(bwa_in_value("batch-1", msg)),
+            bwa_index(bwa_in_value("batch-2", msg)),
+            bwar_index(bwar_in_value("batch-1", msg)),
+            bwar_index(bwar_in_value("batch-2", msg)),
+        ]))
+
+    @inlineCallbacks
+    def test_reverse_migrate_v5_to_v4(self):
+        """
+        A v5 model can be stored in a v4-compatible way.
+        """
+        # Configure the manager to save the older message version.
+        modelcls = self.inbound_v5._modelcls
+        model_name = "%s.%s" % (modelcls.__module__, modelcls.__name__)
+        self.manager.store_versions[model_name] = 4
+
+        msg = self.msg_helper.make_inbound("inbound")
+        batch_1 = self.batch_vnone(key=u"batch-1")
+        batch_2 = self.batch_vnone(key=u"batch-2")
+        new_record = self.inbound_v5(msg["message_id"], msg=msg)
+        new_record.batches.add_key(batch_1.key)
+        new_record.batches.add_key(batch_2.key)
+        yield new_record.save()
+
+        old_record = yield self.inbound_v4.load(new_record.key)
         self.assertEqual(old_record.msg, msg)
         self.assertEqual(old_record.batches.keys(), [batch_1.key, batch_2.key])
 

--- a/vumi_message_store/tests/test_models.py
+++ b/vumi_message_store/tests/test_models.py
@@ -1,0 +1,36 @@
+"""Tests for vumi.components.message_store."""
+
+from vumi.tests.helpers import VumiTestCase
+
+from vumi_message_store.models import (
+    to_reverse_timestamp, from_reverse_timestamp)
+
+
+class TestReverseTimestampUtils(VumiTestCase):
+
+    def test_to_reverse_timestamp(self):
+        """
+        to_reverse_timestamp() turns a vumi_date-formatted string into a
+        reverse timestamp.
+        """
+        self.assertEqual(
+            "FFAAE41F25", to_reverse_timestamp("2015-04-01 12:13:14"))
+        self.assertEqual(
+            "FFAAE41F25", to_reverse_timestamp("2015-04-01 12:13:14.000000"))
+        self.assertEqual(
+            "FFAAE41F25", to_reverse_timestamp("2015-04-01 12:13:14.999999"))
+        self.assertEqual(
+            "FFAAE41F24", to_reverse_timestamp("2015-04-01 12:13:15"))
+        self.assertEqual(
+            "F0F9025FA5", to_reverse_timestamp("4015-04-01 12:13:14"))
+
+    def test_from_reverse_timestamp(self):
+        """
+        from_reverse_timestamp() is the inverse of to_reverse_timestamp().
+        """
+        self.assertEqual(
+            "2015-04-01 12:13:14.000000", from_reverse_timestamp("FFAAE41F25"))
+        self.assertEqual(
+            "2015-04-01 12:13:13.000000", from_reverse_timestamp("FFAAE41F26"))
+        self.assertEqual(
+            "4015-04-01 12:13:14.000000", from_reverse_timestamp("F0F9025FA5"))

--- a/vumi_message_store/tests/test_riak_backend.py
+++ b/vumi_message_store/tests/test_riak_backend.py
@@ -7,21 +7,15 @@ Tests for vumi_message_store.riak_backend.
 from datetime import datetime, timedelta
 
 from twisted.internet.defer import inlineCallbacks
-from vumi.message import VUMI_DATE_FORMAT
+from vumi.message import format_vumi_date
 from vumi.tests.helpers import MessageHelper, VumiTestCase, PersistenceHelper
 
 from vumi_message_store.memory_backend_manager import (
     FakeRiakState, FakeMemoryRiakManager)
 from vumi_message_store.models import (
+    to_reverse_timestamp,
     Batch, CurrentTag, InboundMessage, OutboundMessage, Event)
 from vumi_message_store.riak_backend import MessageStoreRiakBackend
-
-
-def vumi_date(timestamp):
-    """
-    Turn a datetime object into a VUMI_DATE_FORMAT string.
-    """
-    return datetime.strftime(timestamp, VUMI_DATE_FORMAT)
 
 
 class RiakBackendTestMixin(object):
@@ -200,12 +194,14 @@ class RiakBackendTestMixin(object):
         self.assertEqual(stored_msg.batches.keys(), ["mybatch"])
 
         # Make sure we're writing the right indexes.
+        timestamp = format_vumi_date(msg['timestamp'])
+        reverse_ts = to_reverse_timestamp(timestamp)
         self.assertEqual(stored_msg._riak_object.get_indexes(), set([
             ('batches_bin', "mybatch"),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("mybatch", msg['timestamp'])),
             ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("mybatch", msg['timestamp'], msg['from_addr'])),
+             "%s$%s$%s" % ("mybatch", timestamp, msg['from_addr'])),
+            ('batches_with_addresses_reverse_bin',
+             "%s$%s$%s" % ("mybatch", reverse_ts, msg['from_addr'])),
         ]))
 
     @inlineCallbacks
@@ -224,17 +220,19 @@ class RiakBackendTestMixin(object):
             sorted(stored_msg.batches.keys()), ["mybatch", "yourbatch"])
 
         # Make sure we're writing the right indexes.
+        timestamp = format_vumi_date(msg['timestamp'])
+        reverse_ts = to_reverse_timestamp(timestamp)
         self.assertEqual(stored_msg._riak_object.get_indexes(), set([
             ('batches_bin', "mybatch"),
             ('batches_bin', "yourbatch"),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("mybatch", msg['timestamp'])),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("yourbatch", msg['timestamp'])),
             ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("mybatch", msg['timestamp'], msg['from_addr'])),
+             "%s$%s$%s" % ("mybatch", timestamp, msg['from_addr'])),
             ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("yourbatch", msg['timestamp'], msg['from_addr'])),
+             "%s$%s$%s" % ("yourbatch", timestamp, msg['from_addr'])),
+            ('batches_with_addresses_reverse_bin',
+             "%s$%s$%s" % ("mybatch", reverse_ts, msg['from_addr'])),
+            ('batches_with_addresses_reverse_bin',
+             "%s$%s$%s" % ("yourbatch", reverse_ts, msg['from_addr'])),
         ]))
 
     @inlineCallbacks
@@ -253,17 +251,19 @@ class RiakBackendTestMixin(object):
             sorted(stored_msg.batches.keys()), ["mybatch", "yourbatch"])
 
         # Make sure we're writing the right indexes.
+        timestamp = format_vumi_date(msg['timestamp'])
+        reverse_ts = to_reverse_timestamp(timestamp)
         self.assertEqual(stored_msg._riak_object.get_indexes(), set([
             ('batches_bin', "mybatch"),
             ('batches_bin', "yourbatch"),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("mybatch", msg['timestamp'])),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("yourbatch", msg['timestamp'])),
             ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("mybatch", msg['timestamp'], msg['from_addr'])),
+             "%s$%s$%s" % ("mybatch", timestamp, msg['from_addr'])),
             ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("yourbatch", msg['timestamp'], msg['from_addr'])),
+             "%s$%s$%s" % ("yourbatch", timestamp, msg['from_addr'])),
+            ('batches_with_addresses_reverse_bin',
+             "%s$%s$%s" % ("mybatch", reverse_ts, msg['from_addr'])),
+            ('batches_with_addresses_reverse_bin',
+             "%s$%s$%s" % ("yourbatch", reverse_ts, msg['from_addr'])),
         ]))
 
     @inlineCallbacks
@@ -363,12 +363,14 @@ class RiakBackendTestMixin(object):
         self.assertEqual(stored_msg.batches.keys(), ["mybatch"])
 
         # Make sure we're writing the right indexes.
+        timestamp = format_vumi_date(msg['timestamp'])
+        reverse_ts = to_reverse_timestamp(timestamp)
         self.assertEqual(stored_msg._riak_object.get_indexes(), set([
             ('batches_bin', "mybatch"),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("mybatch", msg['timestamp'])),
             ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("mybatch", msg['timestamp'], msg['to_addr'])),
+             "%s$%s$%s" % ("mybatch", timestamp, msg['to_addr'])),
+            ('batches_with_addresses_reverse_bin',
+             "%s$%s$%s" % ("mybatch", reverse_ts, msg['to_addr'])),
         ]))
 
     @inlineCallbacks
@@ -387,17 +389,19 @@ class RiakBackendTestMixin(object):
             sorted(stored_msg.batches.keys()), ["mybatch", "yourbatch"])
 
         # Make sure we're writing the right indexes.
+        timestamp = format_vumi_date(msg['timestamp'])
+        reverse_ts = to_reverse_timestamp(timestamp)
         self.assertEqual(stored_msg._riak_object.get_indexes(), set([
             ('batches_bin', "mybatch"),
             ('batches_bin', "yourbatch"),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("mybatch", msg['timestamp'])),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("yourbatch", msg['timestamp'])),
             ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("mybatch", msg['timestamp'], msg['to_addr'])),
+             "%s$%s$%s" % ("mybatch", timestamp, msg['to_addr'])),
             ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("yourbatch", msg['timestamp'], msg['to_addr'])),
+             "%s$%s$%s" % ("yourbatch", timestamp, msg['to_addr'])),
+            ('batches_with_addresses_reverse_bin',
+             "%s$%s$%s" % ("mybatch", reverse_ts, msg['to_addr'])),
+            ('batches_with_addresses_reverse_bin',
+             "%s$%s$%s" % ("yourbatch", reverse_ts, msg['to_addr'])),
         ]))
 
     @inlineCallbacks
@@ -416,17 +420,19 @@ class RiakBackendTestMixin(object):
             sorted(stored_msg.batches.keys()), ["mybatch", "yourbatch"])
 
         # Make sure we're writing the right indexes.
+        timestamp = format_vumi_date(msg['timestamp'])
+        reverse_ts = to_reverse_timestamp(timestamp)
         self.assertEqual(stored_msg._riak_object.get_indexes(), set([
             ('batches_bin', "mybatch"),
             ('batches_bin', "yourbatch"),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("mybatch", msg['timestamp'])),
-            ('batches_with_timestamps_bin',
-             "%s$%s" % ("yourbatch", msg['timestamp'])),
             ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("mybatch", msg['timestamp'], msg['to_addr'])),
+             "%s$%s$%s" % ("mybatch", timestamp, msg['to_addr'])),
             ('batches_with_addresses_bin',
-             "%s$%s$%s" % ("yourbatch", msg['timestamp'], msg['to_addr'])),
+             "%s$%s$%s" % ("yourbatch", timestamp, msg['to_addr'])),
+            ('batches_with_addresses_reverse_bin',
+             "%s$%s$%s" % ("mybatch", reverse_ts, msg['to_addr'])),
+            ('batches_with_addresses_reverse_bin',
+             "%s$%s$%s" % ("yourbatch", reverse_ts, msg['to_addr'])),
         ]))
 
     @inlineCallbacks
@@ -715,7 +721,7 @@ class RiakBackendTestMixin(object):
             msg = self.msg_helper.make_inbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.backend.list_batch_inbound_keys_with_timestamps(
             batch_id, max_results=3)
@@ -739,7 +745,7 @@ class RiakBackendTestMixin(object):
             msg = self.msg_helper.make_inbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.backend.list_batch_inbound_keys_with_timestamps(
             batch_id, start=all_keys[1][1], max_results=3)
@@ -763,7 +769,7 @@ class RiakBackendTestMixin(object):
             msg = self.msg_helper.make_inbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.backend.list_batch_inbound_keys_with_timestamps(
             batch_id, end=all_keys[-2][1], max_results=3)
@@ -787,7 +793,7 @@ class RiakBackendTestMixin(object):
             msg = self.msg_helper.make_inbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.backend.list_batch_inbound_keys_with_timestamps(
             batch_id, start=all_keys[1][1], end=all_keys[-2][1], max_results=2)
@@ -823,7 +829,7 @@ class RiakBackendTestMixin(object):
             msg = self.msg_helper.make_outbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.backend.list_batch_outbound_keys_with_timestamps(
             batch_id, max_results=3)
@@ -847,7 +853,7 @@ class RiakBackendTestMixin(object):
             msg = self.msg_helper.make_outbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.backend.list_batch_outbound_keys_with_timestamps(
             batch_id, start=all_keys[1][1], max_results=3)
@@ -871,7 +877,7 @@ class RiakBackendTestMixin(object):
             msg = self.msg_helper.make_outbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.backend.list_batch_outbound_keys_with_timestamps(
             batch_id, end=all_keys[-2][1], max_results=3)
@@ -895,7 +901,7 @@ class RiakBackendTestMixin(object):
             msg = self.msg_helper.make_outbound(
                 "Message %s" % (i,), timestamp=timestamp)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
-            all_keys.append((msg["message_id"], vumi_date(timestamp)))
+            all_keys.append((msg["message_id"], format_vumi_date(timestamp)))
 
         keys_p1 = yield self.backend.list_batch_outbound_keys_with_timestamps(
             batch_id, start=all_keys[1][1], end=all_keys[-2][1], max_results=2)
@@ -933,7 +939,7 @@ class RiakBackendTestMixin(object):
                 "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.backend.list_batch_inbound_keys_with_addresses(
             batch_id, max_results=3)
@@ -959,7 +965,7 @@ class RiakBackendTestMixin(object):
                 "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.backend.list_batch_inbound_keys_with_addresses(
             batch_id, start=all_keys[1][1], max_results=3)
@@ -985,7 +991,7 @@ class RiakBackendTestMixin(object):
                 "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.backend.list_batch_inbound_keys_with_addresses(
             batch_id, end=all_keys[-2][1], max_results=3)
@@ -1011,7 +1017,7 @@ class RiakBackendTestMixin(object):
                 "Message %s" % (i,), timestamp=timestamp, from_addr=addr)
             yield self.backend.add_inbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.backend.list_batch_inbound_keys_with_addresses(
             batch_id, start=all_keys[1][1], end=all_keys[-2][1], max_results=2)
@@ -1049,7 +1055,7 @@ class RiakBackendTestMixin(object):
                 "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.backend.list_batch_outbound_keys_with_addresses(
             batch_id, max_results=3)
@@ -1075,7 +1081,7 @@ class RiakBackendTestMixin(object):
                 "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.backend.list_batch_outbound_keys_with_addresses(
             batch_id, start=all_keys[1][1], max_results=3)
@@ -1101,7 +1107,7 @@ class RiakBackendTestMixin(object):
                 "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.backend.list_batch_outbound_keys_with_addresses(
             batch_id, end=all_keys[-2][1], max_results=3)
@@ -1127,7 +1133,7 @@ class RiakBackendTestMixin(object):
                 "Message %s" % (i,), timestamp=timestamp, to_addr=addr)
             yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
             all_keys.append(
-                (msg["message_id"], vumi_date(timestamp), addr))
+                (msg["message_id"], format_vumi_date(timestamp), addr))
 
         keys_p1 = yield self.backend.list_batch_outbound_keys_with_addresses(
             batch_id, start=all_keys[1][1], end=all_keys[-2][1], max_results=2)
@@ -1171,11 +1177,12 @@ class RiakBackendTestMixin(object):
             self.msg_helper.make_delivery_report(
                 msg, timestamp=(start + timedelta(seconds=4))),
         ]
-        all_keys = [(ack["event_id"], vumi_date(ack["timestamp"]), "ack")]
+        all_keys = [(ack["event_id"],
+                    format_vumi_date(ack["timestamp"]), "ack")]
         for dr in drs:
             yield self.backend.add_event(dr)
             all_keys.append(
-                (dr["event_id"], vumi_date(dr["timestamp"]),
+                (dr["event_id"], format_vumi_date(dr["timestamp"]),
                  "delivery_report.delivered"))
 
         keys_p1 = yield self.backend.list_message_event_keys_with_statuses(

--- a/vumi_message_store/tests/test_test_helpers.py
+++ b/vumi_message_store/tests/test_test_helpers.py
@@ -1,0 +1,89 @@
+from datetime import timedelta
+
+from twisted.internet.defer import inlineCallbacks
+
+from vumi.message import parse_vumi_date
+from vumi.tests.helpers import VumiTestCase, MessageHelper
+from vumi_message_store.tests.helpers import MessageSequenceHelper
+
+
+class FakeBackend(object):
+    """
+    Simple stub riak backend for testing the MessageSequenceHelper
+    """
+    def __init__(self):
+        self.inbound = []
+        self.outbound = []
+
+    def batch_start(self):
+        return "batch_id"
+
+    def add_inbound_message(self, msg, batch_ids=()):
+        self.inbound.append(msg)
+
+    def add_outbound_message(self, msg, batch_ids=()):
+        self.outbound.append(msg)
+
+
+class TestMessageSequenceHelper(VumiTestCase):
+    def setUp(self):
+        self.backend = FakeBackend()
+        self.msg_helper = self.add_helper(MessageHelper())
+        self.msg_seq_helper = (
+            MessageSequenceHelper(self.backend, self.msg_helper))
+
+    @inlineCallbacks
+    def test_inbound_msg_count(self):
+        """
+        When creating an inbound message sequence, the correct number of
+        messages are created and stored
+        """
+        _, all_keys = (
+            yield self.msg_seq_helper.create_inbound_message_sequence(
+                msg_count=3))
+
+        self.assertEqual(len(all_keys), 3)
+        self.assertEqual(len(self.backend.inbound), 3)
+
+    @inlineCallbacks
+    def test_outbound_msg_count(self):
+        """
+        When creating an outbound message sequence, the correct number of
+        messages are created and stored
+        """
+        _, all_keys = (
+            yield self.msg_seq_helper.create_outbound_message_sequence(
+                msg_count=3))
+
+        self.assertEqual(len(all_keys), 3)
+        self.assertEqual(len(self.backend.outbound), 3)
+
+    @inlineCallbacks
+    def test_inbound_delay_seconds(self):
+        """
+        When creating an inbound message sequence, the messages are returned in
+        ascending timestamp order and the delay between each timestamp is
+        correct
+        """
+        batch_id, all_keys = (
+            yield self.msg_seq_helper.create_inbound_message_sequence(
+                msg_count=3, delay_seconds=2))
+
+        timestamps = [parse_vumi_date(ts) for _, ts, _ in all_keys]
+        self.assertEqual(timestamps[1] - timestamps[0], timedelta(seconds=2))
+        self.assertEqual(timestamps[2] - timestamps[1], timedelta(seconds=2))
+
+    @inlineCallbacks
+    def test_outbound_delay_seconds(self):
+        """
+        When creating an outbound message sequence, the messages are returned
+        in ascending timestamp order and the delay between each timestamp is
+        correct
+        """
+        batch_id, all_keys = (
+            yield self.msg_seq_helper.create_outbound_message_sequence(
+                msg_count=3, delay_seconds=2))
+
+        timestamps = [parse_vumi_date(ts) for _, ts, _ in all_keys]
+        self.assertEqual(timestamps[1] - timestamps[0], timedelta(seconds=2))
+        self.assertEqual(timestamps[2] - timestamps[1], timedelta(seconds=2))


### PR DESCRIPTION
`InboundMessage` is version 3 should be 5
`OutboundMessage` is version 3 should be 5
`Event` is version 1 should be 2

Need to:
- Add migrations (from Vumi)
- Add tests (from Vumi)
- Add methods to access reverse timestamp indexes introduced in schema v5 (but not adding to message store interface yet).
