### PR TITLE
Expose batch info cache rebuild on batch manager

### DIFF
--- a/vumi_message_store/interfaces.py
+++ b/vumi_message_store/interfaces.py
@@ -65,6 +65,21 @@ class IMessageStoreBatchManager(Interface):
             If async, a Deferred is returned instead.
         """
 
+    def rebuild_cache(batch_id, qms):
+        """
+        Rebuild the cache using the provided IQueryMessageStore implementation.
+
+        :param batch_id:
+            The batch identifier for the batch to operate on.
+
+        :param qms:
+            An `IQueryMessageStore` provider to rebuild the cache from.
+
+        :returns:
+            ``None``.
+            If async, a Deferred is returned instead.
+        """
+
 
 class IOperationalMessageStore(Interface):
     """

--- a/vumi_message_store/message_store.py
+++ b/vumi_message_store/message_store.py
@@ -63,6 +63,12 @@ class MessageStoreBatchManager(object):
         """
         return self.riak_backend.get_tag_info(tag)
 
+    def rebuild_cache(self, batch_id, qms):
+        """
+        Rebuild the cache using the provided IQueryMessageStore implementation.
+        """
+        return self.batch_info_cache.rebuild_cache(batch_id, qms)
+
 
 @implementer(IOperationalMessageStore)
 class OperationalMessageStore(object):


### PR DESCRIPTION
Currently one needs to dig around inside the `batch_info_cache` attribute, which isn't part of the public API.
