### PR TITLE
Fix `_reverse` method timestamp parameters

### DIFF
--- a/vumi_message_store/riak_backend.py
+++ b/vumi_message_store/riak_backend.py
@@ -295,9 +295,12 @@ class MessageStoreRiakBackend(object):
             end = to_reverse_timestamp(end)
         if max_results is None:
             max_results = self.DEFAULT_MAX_RESULTS
-        start_value, end_value = self._start_end_values(batch_id, start, end)
+        # The index is an inverse timestamp so the start and end range values
+        # are swapped.
+        start, end = end, start
+        start_range, end_range = self._start_end_values(batch_id, start, end)
         results = yield self.inbound_messages.index_keys_page(
-            'batches_with_addresses_reverse', start_value, end_value,
+            'batches_with_addresses_reverse', start_range, end_range,
             return_terms=True, max_results=max_results)
         returnValue(IndexPageWrapper(
             key_with_rts_and_value_formatter, self, batch_id, results))
@@ -316,9 +319,12 @@ class MessageStoreRiakBackend(object):
             end = to_reverse_timestamp(end)
         if max_results is None:
             max_results = self.DEFAULT_MAX_RESULTS
-        start_value, end_value = self._start_end_values(batch_id, start, end)
+        # The index is an inverse timestamp so the start and end range values
+        # are swapped.
+        start, end = end, start
+        start_range, end_range = self._start_end_values(batch_id, start, end)
         results = yield self.outbound_messages.index_keys_page(
-            'batches_with_addresses_reverse', start_value, end_value,
+            'batches_with_addresses_reverse', start_range, end_range,
             return_terms=True, max_results=max_results)
         returnValue(IndexPageWrapper(
             key_with_rts_and_value_formatter, self, batch_id, results))

--- a/vumi_message_store/tests/test_message_store.py
+++ b/vumi_message_store/tests/test_message_store.py
@@ -1068,11 +1068,11 @@ class TestQueryMessageStore(VumiTestCase):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.store.list_batch_inbound_keys_with_addresses_reverse(
                 batch_id, max_results=3))
-        # Paginated results are sorted by timestamp.
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[:3])
 
         keys_p2 = yield keys_p1.next_page()
@@ -1086,15 +1086,15 @@ class TestQueryMessageStore(VumiTestCase):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.store.list_batch_inbound_keys_with_addresses_reverse(
                 batch_id, start=all_keys[1][1], max_results=3))
-        # Paginated results are sorted by timestamp.
-        self.assertEqual(list(keys_p1), all_keys[1:4])
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
+        self.assertEqual(list(keys_p1), all_keys[0:3])
 
         keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[4:])
+        self.assertEqual(list(keys_p2), all_keys[3:-1])
 
     @inlineCallbacks
     def test_list_batch_inbound_keys_with_addresses_reverse_range_end(self):
@@ -1104,15 +1104,15 @@ class TestQueryMessageStore(VumiTestCase):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.store.list_batch_inbound_keys_with_addresses_reverse(
                 batch_id, end=all_keys[-2][1], max_results=3))
-        # Paginated results are sorted by timestamp.
-        self.assertEqual(list(keys_p1), all_keys[0:3])
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
+        self.assertEqual(list(keys_p1), all_keys[1:4])
 
         keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:-1])
+        self.assertEqual(list(keys_p2), all_keys[4:])
 
     @inlineCallbacks
     def test_list_batch_inbound_keys_with_addresses_reverse_range(self):
@@ -1122,12 +1122,12 @@ class TestQueryMessageStore(VumiTestCase):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.store.list_batch_inbound_keys_with_addresses_reverse(
                 batch_id, start=all_keys[1][1], end=all_keys[-2][1],
                 max_results=2))
-        # Paginated results are sorted by timestamp.
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[1:3])
 
         keys_p2 = yield keys_p1.next_page()
@@ -1154,11 +1154,11 @@ class TestQueryMessageStore(VumiTestCase):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.store.list_batch_outbound_keys_with_addresses_reverse(
                 batch_id, max_results=3))
-        # Paginated results are sorted by timestamp.
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[:3])
 
         keys_p2 = yield keys_p1.next_page()
@@ -1172,15 +1172,15 @@ class TestQueryMessageStore(VumiTestCase):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.store.list_batch_outbound_keys_with_addresses_reverse(
                 batch_id, start=all_keys[1][1], max_results=3))
-        # Paginated results are sorted by timestamp.
-        self.assertEqual(list(keys_p1), all_keys[1:4])
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
+        self.assertEqual(list(keys_p1), all_keys[0:3])
 
         keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[4:])
+        self.assertEqual(list(keys_p2), all_keys[3:-1])
 
     @inlineCallbacks
     def test_list_batch_outbound_keys_with_addresses_reverse_range_end(self):
@@ -1190,15 +1190,15 @@ class TestQueryMessageStore(VumiTestCase):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.store.list_batch_outbound_keys_with_addresses_reverse(
                 batch_id, end=all_keys[-2][1], max_results=3))
-        # Paginated results are sorted by timestamp.
-        self.assertEqual(list(keys_p1), all_keys[0:3])
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
+        self.assertEqual(list(keys_p1), all_keys[1:4])
 
         keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:-1])
+        self.assertEqual(list(keys_p2), all_keys[4:])
 
     @inlineCallbacks
     def test_list_batch_outbound_keys_with_addresses_reverse_range(self):
@@ -1208,12 +1208,12 @@ class TestQueryMessageStore(VumiTestCase):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.store.list_batch_outbound_keys_with_addresses_reverse(
                 batch_id, start=all_keys[1][1], end=all_keys[-2][1],
                 max_results=2))
-        # Paginated results are sorted by timestamp.
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[1:3])
 
         keys_p2 = yield keys_p1.next_page()

--- a/vumi_message_store/tests/test_riak_backend.py
+++ b/vumi_message_store/tests/test_riak_backend.py
@@ -1020,11 +1020,11 @@ class RiakBackendTestMixin(object):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.backend.list_batch_inbound_keys_with_addresses_reverse(
                 batch_id, max_results=3))
-        # Paginated results are sorted by timestamp.
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[:3])
 
         keys_p2 = yield keys_p1.next_page()
@@ -1038,15 +1038,15 @@ class RiakBackendTestMixin(object):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.backend.list_batch_inbound_keys_with_addresses_reverse(
                 batch_id, start=all_keys[1][1], max_results=3))
-        # Paginated results are sorted by timestamp.
-        self.assertEqual(list(keys_p1), all_keys[1:4])
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
+        self.assertEqual(list(keys_p1), all_keys[0:3])
 
         keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[4:])
+        self.assertEqual(list(keys_p2), all_keys[3:-1])
 
     @inlineCallbacks
     def test_list_batch_inbound_keys_with_addresses_reverse_range_end(self):
@@ -1056,15 +1056,15 @@ class RiakBackendTestMixin(object):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.backend.list_batch_inbound_keys_with_addresses_reverse(
                 batch_id, end=all_keys[-2][1], max_results=3))
-        # Paginated results are sorted by timestamp.
-        self.assertEqual(list(keys_p1), all_keys[0:3])
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
+        self.assertEqual(list(keys_p1), all_keys[1:4])
 
         keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:-1])
+        self.assertEqual(list(keys_p2), all_keys[4:])
 
     @inlineCallbacks
     def test_list_batch_inbound_keys_with_addresses_reverse_range(self):
@@ -1074,12 +1074,12 @@ class RiakBackendTestMixin(object):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.backend.list_batch_inbound_keys_with_addresses_reverse(
                 batch_id, start=all_keys[1][1], end=all_keys[-2][1],
                 max_results=2))
-        # Paginated results are sorted by timestamp.
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[1:3])
 
         keys_p2 = yield keys_p1.next_page()
@@ -1106,11 +1106,11 @@ class RiakBackendTestMixin(object):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.backend.list_batch_outbound_keys_with_addresses_reverse(
                 batch_id, max_results=3))
-        # Paginated results are sorted by timestamp.
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[:3])
 
         keys_p2 = yield keys_p1.next_page()
@@ -1124,15 +1124,15 @@ class RiakBackendTestMixin(object):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.backend.list_batch_outbound_keys_with_addresses_reverse(
                 batch_id, start=all_keys[1][1], max_results=3))
-        # Paginated results are sorted by timestamp.
-        self.assertEqual(list(keys_p1), all_keys[1:4])
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
+        self.assertEqual(list(keys_p1), all_keys[0:3])
 
         keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[4:])
+        self.assertEqual(list(keys_p2), all_keys[3:-1])
 
     @inlineCallbacks
     def test_list_batch_outbound_keys_with_addresses_reverse_range_end(self):
@@ -1142,15 +1142,15 @@ class RiakBackendTestMixin(object):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.backend.list_batch_outbound_keys_with_addresses_reverse(
                 batch_id, end=all_keys[-2][1], max_results=3))
-        # Paginated results are sorted by timestamp.
-        self.assertEqual(list(keys_p1), all_keys[0:3])
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
+        self.assertEqual(list(keys_p1), all_keys[1:4])
 
         keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:-1])
+        self.assertEqual(list(keys_p2), all_keys[4:])
 
     @inlineCallbacks
     def test_list_batch_outbound_keys_with_addresses_reverse_range(self):
@@ -1160,12 +1160,12 @@ class RiakBackendTestMixin(object):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys.reverse()
         keys_p1 = (
             yield self.backend.list_batch_outbound_keys_with_addresses_reverse(
                 batch_id, start=all_keys[1][1], end=all_keys[-2][1],
                 max_results=2))
-        # Paginated results are sorted by timestamp.
+        # Paginated results are sorted by descending timestamp.
+        all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[1:3])
 
         keys_p2 = yield keys_p1.next_page()


### PR DESCRIPTION
Currently `end` must be < `start`.
The values must be swapped internally.
