### PR TITLE
Implement `list_batch_events`

### DIFF
--- a/vumi_message_store/interfaces.py
+++ b/vumi_message_store/interfaces.py
@@ -357,6 +357,25 @@ class IQueryMessageStore(Interface):
             If async, a Deferred is returned instead.
         """
 
+    def list_batch_events(batch_id, start=None, end=None):
+        """
+        List event keys with timestamps and statuses for the given batch.
+
+        :param batch_id:
+            The batch identifier for the batch to operate on.
+
+        :param start:
+            Timestamp denoting the start of a range query.
+
+        :param end:
+            Timestamp denoting the end of a range query.
+
+        :returns:
+            An IndexPage object containing a list of tuples of event key,
+            timestamp, and statuses.
+            If async, a Deferred is returned instead.
+        """
+
     def get_batch_info_status(batch_id):
         """
         Return a dictionary containing the latest event stats for the given

--- a/vumi_message_store/interfaces.py
+++ b/vumi_message_store/interfaces.py
@@ -142,12 +142,14 @@ class IOperationalMessageStore(Interface):
             If async, a Deferred is returned instead.
         """
 
-    def add_event(event):
+    def add_event(event, batch_ids=()):
         """
         Add an event to the message store.
 
         :param event:
             The TransportEvent to add.
+        :param batch_ids:
+            Sequence of batch identifiers to add the event to.
 
         :returns:
             ``None``.

--- a/vumi_message_store/message_store.py
+++ b/vumi_message_store/message_store.py
@@ -115,20 +115,12 @@ class OperationalMessageStore(object):
         return self.riak_backend.get_outbound_message(msg_id)
 
     @Manager.calls_manager
-    def add_event(self, event):
+    def add_event(self, event, batch_ids=()):
         """
         Add an event to the message store.
-
-        NOTE: This loads the message for the event so we can find the relevant
-              batches.
         """
-        yield self.riak_backend.add_event(event)
-        outbound_message = yield self.riak_backend.get_raw_outbound_message(
-            event["user_message_id"])
-        if outbound_message is None:
-            # Should we emit a warning or something here?
-            return
-        for batch_id in outbound_message.batches.keys():
+        yield self.riak_backend.add_event(event, batch_ids=batch_ids)
+        for batch_id in batch_ids:
             yield self.batch_info_cache.add_event(batch_id, event)
 
     def get_event(self, event_id):

--- a/vumi_message_store/message_store.py
+++ b/vumi_message_store/message_store.py
@@ -235,6 +235,17 @@ class QueryMessageStore(object):
         return self.riak_backend.list_message_event_keys_with_statuses(
             message_id, max_results=max_results)
 
+    def list_batch_events(self, batch_id, start=None, end=None,
+                          max_results=None):
+        """
+        List event keys with timestamps and statuses for the given outbound
+        message.
+        """
+        return self.riak_backend.list_batch_events(batch_id,
+                                                   start=start,
+                                                   end=end,
+                                                   max_results=max_results)
+
     def get_batch_info_status(self, batch_id):
         """
         Return a dictionary containing the latest event stats for the given

--- a/vumi_message_store/riak_backend.py
+++ b/vumi_message_store/riak_backend.py
@@ -210,7 +210,7 @@ class MessageStoreRiakBackend(object):
             'message', message_id, max_results=max_results,
             continuation=continuation)
 
-    def _start_end_values(self, batch_id, start, end):
+    def _start_end_range(self, batch_id, start, end):
         if start is not None:
             start_value = "%s$%s" % (batch_id, start)
         else:
@@ -223,22 +223,26 @@ class MessageStoreRiakBackend(object):
             end_value = "%s%s" % (batch_id, "%")  # chr(ord('$') + 1)
         return start_value, end_value
 
+    def _start_end_range_reverse(self, batch_id, start, end):
+        if start is not None:
+            start = to_reverse_timestamp(start)
+        if end is not None:
+            end = to_reverse_timestamp(end)
+        # The index is an inverse timestamp so the start and end range values
+        # are swapped.
+        start, end = end, start
+        return self._start_end_range(batch_id, start, end)
+
     @Manager.calls_manager
     def list_batch_inbound_keys_with_timestamps(self, batch_id, start=None,
                                                 end=None, max_results=None):
         """
         List inbound message keys with timestamps for the given batch.
         """
-        if start is not None:
-            start = to_reverse_timestamp(start)
-        if end is not None:
-            end = to_reverse_timestamp(end)
         if max_results is None:
             max_results = self.DEFAULT_MAX_RESULTS
-        # The index is an inverse timestamp so the start and end range values
-        # are swapped.
-        start, end = end, start
-        start_range, end_range = self._start_end_values(batch_id, start, end)
+        start_range, end_range = (
+            self._start_end_range_reverse(batch_id, start, end))
         results = yield self.inbound_messages.index_keys_page(
             'batches_with_addresses_reverse', start_range, end_range,
             return_terms=True, max_results=max_results)
@@ -251,16 +255,10 @@ class MessageStoreRiakBackend(object):
         """
         List outbound message keys with timestamps for the given batch.
         """
-        if start is not None:
-            start = to_reverse_timestamp(start)
-        if end is not None:
-            end = to_reverse_timestamp(end)
         if max_results is None:
             max_results = self.DEFAULT_MAX_RESULTS
-        # The index is an inverse timestamp so the start and end range values
-        # are swapped.
-        start, end = end, start
-        start_range, end_range = self._start_end_values(batch_id, start, end)
+        start_range, end_range = (
+            self._start_end_range_reverse(batch_id, start, end))
         results = yield self.outbound_messages.index_keys_page(
             'batches_with_addresses_reverse', start_range, end_range,
             return_terms=True, max_results=max_results)
@@ -274,16 +272,10 @@ class MessageStoreRiakBackend(object):
         List inbound message keys with timestamps and addresses in descending
         timestamp order for the given batch.
         """
-        if start is not None:
-            start = to_reverse_timestamp(start)
-        if end is not None:
-            end = to_reverse_timestamp(end)
         if max_results is None:
             max_results = self.DEFAULT_MAX_RESULTS
-        # The index is an inverse timestamp so the start and end range values
-        # are swapped.
-        start, end = end, start
-        start_range, end_range = self._start_end_values(batch_id, start, end)
+        start_range, end_range = (
+            self._start_end_range_reverse(batch_id, start, end))
         results = yield self.inbound_messages.index_keys_page(
             'batches_with_addresses_reverse', start_range, end_range,
             return_terms=True, max_results=max_results)
@@ -297,16 +289,10 @@ class MessageStoreRiakBackend(object):
         List outbound message keys with timestamps and addresses in descending
         timestamp order for the given batch.
         """
-        if start is not None:
-            start = to_reverse_timestamp(start)
-        if end is not None:
-            end = to_reverse_timestamp(end)
         if max_results is None:
             max_results = self.DEFAULT_MAX_RESULTS
-        # The index is an inverse timestamp so the start and end range values
-        # are swapped.
-        start, end = end, start
-        start_range, end_range = self._start_end_values(batch_id, start, end)
+        start_range, end_range = (
+            self._start_end_range_reverse(batch_id, start, end))
         results = yield self.outbound_messages.index_keys_page(
             'batches_with_addresses_reverse', start_range, end_range,
             return_terms=True, max_results=max_results)
@@ -322,7 +308,7 @@ class MessageStoreRiakBackend(object):
         """
         if max_results is None:
             max_results = self.DEFAULT_MAX_RESULTS
-        start_value, end_value = self._start_end_values(message_id, None, None)
+        start_value, end_value = self._start_end_range(message_id, None, None)
         results = yield self.events.index_keys_page(
             'message_with_status', start_value, end_value, return_terms=True,
             max_results=max_results)
@@ -336,16 +322,10 @@ class MessageStoreRiakBackend(object):
         List event keys with timestamps and statuses for the given outbound
         message.
         """
-        if start is not None:
-            start = to_reverse_timestamp(start)
-        if end is not None:
-            end = to_reverse_timestamp(end)
         if max_results is None:
             max_results = self.DEFAULT_MAX_RESULTS
-        # The index is an inverse timestamp so the start and end range values
-        # are swapped.
-        start, end = end, start
-        start_range, end_range = self._start_end_values(batch_id, start, end)
+        start_range, end_range = (
+            self._start_end_range_reverse(batch_id, start, end))
         results = yield self.events.index_keys_page(
             'batches_with_statuses_reverse', start_range, end_range,
             return_terms=True, max_results=max_results)

--- a/vumi_message_store/riak_backend.py
+++ b/vumi_message_store/riak_backend.py
@@ -146,7 +146,7 @@ class MessageStoreRiakBackend(object):
         returnValue(msg.msg if msg is not None else None)
 
     @Manager.calls_manager
-    def add_event(self, event):
+    def add_event(self, event, batch_ids=()):
         """
         Store an event in Riak.
         """
@@ -157,6 +157,10 @@ class MessageStoreRiakBackend(object):
             event_record = self.events(event_id, event=event, message=msg_id)
         else:
             event_record.event = event
+
+        for batch_id in batch_ids:
+            event_record.batches.add_key(batch_id)
+
         yield event_record.save()
 
     def get_raw_event(self, event_id):

--- a/vumi_message_store/tests/test_message_store.py
+++ b/vumi_message_store/tests/test_message_store.py
@@ -16,10 +16,6 @@ from vumi_message_store.message_store import (
 from vumi_message_store.tests.helpers import MessageSequenceHelper
 
 
-# TODO: Better way to test indexes. Currently indexes are retrieved
-#       using ._riak_object.get_indexes().
-
-
 class TestMessageStoreBatchManager(VumiTestCase):
 
     @inlineCallbacks
@@ -263,8 +259,8 @@ class TestOperationalMessageStore(VumiTestCase):
     def test_add_inbound_message_with_batch_id(self):
         """
         When an inbound message is added with a batch identifier, that batch
-        identifier is stored with it and indexed. Additionally, it is added to
-        the batch info cache.
+        identifier is stored with it. Additionally, it is added to the batch
+        info cache.
         """
         yield self.bi_cache.batch_start("mybatch")
         msg = self.msg_helper.make_inbound("apples")
@@ -377,8 +373,8 @@ class TestOperationalMessageStore(VumiTestCase):
     def test_add_outbound_message_with_batch_id(self):
         """
         When an outbound message is added with a batch identifier, that batch
-        identifier is stored with it and indexed. Additionally, it is added to
-        the batch info cache.
+        identifier is stored with it. Additionally, it is added to the batch
+        info cache.
         """
         yield self.bi_cache.batch_start("mybatch")
         msg = self.msg_helper.make_outbound("apples")
@@ -468,13 +464,6 @@ class TestOperationalMessageStore(VumiTestCase):
         stored_event = yield self.backend.get_raw_event(ack["event_id"])
         self.assertEqual(stored_event.event, ack)
 
-        # Make sure we're writing the right indexes.
-        self.assertEqual(stored_event._riak_object.get_indexes(), set([
-            ("message_bin", ack["user_message_id"]),
-            ("message_with_status_bin",
-             "%s$%s$%s" % (ack["user_message_id"], ack["timestamp"], "ack")),
-        ]))
-
     @inlineCallbacks
     def test_add_ack_event_no_stored_outbound(self):
         """
@@ -490,19 +479,11 @@ class TestOperationalMessageStore(VumiTestCase):
         stored_event = yield self.backend.get_raw_event(ack["event_id"])
         self.assertEqual(stored_event.event, ack)
 
-        # Make sure we're writing the right indexes.
-        self.assertEqual(stored_event._riak_object.get_indexes(), set([
-            ("message_bin", ack["user_message_id"]),
-            ("message_with_status_bin",
-             "%s$%s$%s" % (ack["user_message_id"], ack["timestamp"], "ack")),
-        ]))
-
     @inlineCallbacks
     def test_add_ack_event_with_batch_id(self):
         """
         When an event is added with a batch identifier, that batch identifier
-        is stored with it and indexed. Additionally, it is added to the batch
-        info cache.
+        is stored with it. Additionally, it is added to the batch info cache.
         """
         yield self.bi_cache.batch_start("mybatch")
         msg = self.msg_helper.make_outbound("apples")
@@ -558,8 +539,7 @@ class TestOperationalMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_add_delivery_report_event(self):
         """
-        When a delivery report event is added, delivery status is included in
-        the indexed status.
+        When a delivery report event is added it is stored in Riak.
         """
         msg = self.msg_helper.make_outbound("apples")
         dr = self.msg_helper.make_delivery_report(msg)
@@ -569,14 +549,6 @@ class TestOperationalMessageStore(VumiTestCase):
         yield self.backend.add_event(dr)
         stored_event = yield self.backend.get_raw_event(dr["event_id"])
         self.assertEqual(stored_event.event, dr)
-
-        # Make sure we're writing the right indexes.
-        self.assertEqual(stored_event._riak_object.get_indexes(), set([
-            ("message_bin", dr["user_message_id"]),
-            ("message_with_status_bin",
-             "%s$%s$%s" % (dr["user_message_id"], dr["timestamp"],
-                           "delivery_report.delivered")),
-        ]))
 
     @inlineCallbacks
     def test_add_ack_event_again(self):

--- a/vumi_message_store/tests/test_riak_backend.py
+++ b/vumi_message_store/tests/test_riak_backend.py
@@ -1137,6 +1137,81 @@ class RiakBackendTestMixin(object):
             "badmsg")
         self.assertEqual(list(keys_page), [])
 
+    @inlineCallbacks
+    def test_list_batch_events(self):
+        """
+        When we ask for a list of event keys by for a batch, we get an
+        IndexPageWrapper containing the first page of results and can ask for
+        following pages until all results are delivered.
+        """
+        batch_id, msg_id, all_keys = (
+            yield self.msg_seq_helper.create_ack_event_sequence())
+
+        keys_p1 = yield self.backend.list_batch_events(batch_id, max_results=3)
+        self.assertEqual(list(keys_p1), all_keys[:3])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[3:])
+
+    @inlineCallbacks
+    def test_list_batch_events_range_start(self):
+        """
+        When we ask for a list of event keys for a batch, we can specify a
+        start timestamp.
+        """
+        batch_id, msg_id, all_keys = (
+            yield self.msg_seq_helper.create_ack_event_sequence())
+        keys_p1 = yield self.backend.list_batch_events(
+            batch_id, start=all_keys[-2][1], max_results=3)
+        # Paginated results are sorted by descending timestamp.
+        self.assertEqual(list(keys_p1), all_keys[0:3])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[3:-1])
+
+    @inlineCallbacks
+    def test_list_batch_events_range_end(self):
+        """
+        When we ask for a list of event keys for a batch, we can specify an end
+        timestamp.
+        """
+        batch_id, msg_id, all_keys = (
+            yield self.msg_seq_helper.create_ack_event_sequence())
+        keys_p1 = yield self.backend.list_batch_events(
+            batch_id, end=all_keys[1][1], max_results=3)
+        # Paginated results are sorted by descending timestamp.
+        self.assertEqual(list(keys_p1), all_keys[1:4])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[4:])
+
+    @inlineCallbacks
+    def test_list_batch_events_range(self):
+        """
+        When we ask for a list of event keys for a batch, we can specify both
+        ends of the range.
+        """
+        batch_id, msg_id, all_keys = (
+            yield self.msg_seq_helper.create_ack_event_sequence())
+        keys_p1 = yield self.backend.list_batch_events(
+            batch_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
+        # Paginated results are sorted by descending timestamp.
+        self.assertEqual(list(keys_p1), all_keys[1:3])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[3:-1])
+
+    @inlineCallbacks
+    def test_list_batch_events_empty(self):
+        """
+        When we ask for a list of event keys for an empty batch, we get an
+        empty IndexPageWrapper.
+        """
+        batch_id = yield self.backend.batch_start()
+        keys_page = yield self.backend.list_batch_events(
+            batch_id)
+        self.assertEqual(list(keys_page), [])
+
 
 class TestMessageStoreRiakBackend(RiakBackendTestMixin, VumiTestCase):
 


### PR DESCRIPTION
The new `batches_with_statuses_reverse` index on Events is not yet used. This is a pre-requisite to #6 and will be the first example of a "cleaned up" method as in #20. 
