### PR TITLE
Remove message list variants

### DIFF
--- a/vumi_message_store/api/message_export_resources.py
+++ b/vumi_message_store/api/message_export_resources.py
@@ -140,7 +140,7 @@ class MessageExportProxyResource(Resource):
 class InboundResource(MessageExportProxyResource):
 
     def get_keys_page(self, message_store, batch_id, start, end):
-        return message_store.list_batch_inbound_keys_with_addresses(
+        return message_store.list_batch_inbound_messages(
             batch_id, start=start, end=end)
 
     def get_message_keys(self, keys_page):
@@ -153,7 +153,7 @@ class InboundResource(MessageExportProxyResource):
 class OutboundResource(MessageExportProxyResource):
 
     def get_keys_page(self, message_store, batch_id, start, end):
-        return message_store.list_batch_outbound_keys_with_addresses(
+        return message_store.list_batch_outbound_messages(
             batch_id, start=start, end=end)
 
     def get_message_keys(self, keys_page):

--- a/vumi_message_store/batch_info_cache.py
+++ b/vumi_message_store/batch_info_cache.py
@@ -370,7 +370,7 @@ class BatchInfoCache(object):
         batch into the cache and counting all the messages.
         """
         inbound_page = yield qms.list_batch_inbound_messages(
-            batch_id, max_results=page_size)
+            batch_id, page_size=page_size)
         count = 0
         recents_added = False
         while inbound_page is not None:
@@ -404,7 +404,7 @@ class BatchInfoCache(object):
         batch into the cache and counting all the messages.
         """
         outbound_page = yield qms.list_batch_outbound_messages(
-            batch_id, max_results=page_size)
+            batch_id, page_size=page_size)
         count = 0
         recents_added = False
         while outbound_page is not None:
@@ -436,8 +436,7 @@ class BatchInfoCache(object):
         Rebuild the cache by loading the latest events for the given batch into
         the cache and counting all the events.
         """
-        event_page = yield qms.list_batch_events(
-            batch_id, max_results=page_size)
+        event_page = yield qms.list_batch_events(batch_id, page_size=page_size)
         count = 0
         recents_added = False
         statuses = {}

--- a/vumi_message_store/batch_info_cache.py
+++ b/vumi_message_store/batch_info_cache.py
@@ -365,7 +365,7 @@ class BatchInfoCache(object):
         Rebuild the cache by loading the latest inbound messages for the given
         batch into the cache and counting all the messages.
         """
-        inbound_page = yield qms.list_batch_inbound_keys_with_addresses(
+        inbound_page = yield qms.list_batch_inbound_messages(
             batch_id, max_results=page_size)
         count = 0
         recents_added = False
@@ -402,7 +402,7 @@ class BatchInfoCache(object):
         Rebuild the cache by loading the latest outbound messages for the given
         batch into the cache and counting all the messages.
         """
-        outbound_page = yield qms.list_batch_outbound_keys_with_addresses(
+        outbound_page = yield qms.list_batch_outbound_messages(
             batch_id, max_results=page_size)
         count = 0
         recents_added = False

--- a/vumi_message_store/interfaces.py
+++ b/vumi_message_store/interfaces.py
@@ -240,7 +240,8 @@ class IQueryMessageStore(Interface):
 
         :returns:
             An IndexPage object containing a list of tuples of inbound message
-            key, timestamp, and from_addr.
+            key, timestamp, and from_addr. The list will be in descending
+            timestamp order.
             If async, a Deferred is returned instead.
         """
 
@@ -260,7 +261,8 @@ class IQueryMessageStore(Interface):
 
         :returns:
             An IndexPage object containing a list of tuples of outbound message
-            key, timestamp, and to_addr.
+            key, timestamp, and to_addr. The list will be in descending
+            timestamp order.
             If async, a Deferred is returned instead.
         """
 
@@ -280,7 +282,8 @@ class IQueryMessageStore(Interface):
 
         :returns:
             An IndexPage object containing a list tupled of event key,
-            timestamp, and event status.
+            timestamp, and event status. The list will be in ascending
+            timestamp order.
             If async, a Deferred is returned instead.
         """
 
@@ -299,7 +302,8 @@ class IQueryMessageStore(Interface):
 
         :returns:
             An IndexPage object containing a list of tuples of event key,
-            timestamp, and statuses.
+            timestamp, and event status. The list will be in descending
+            timestamp order.
             If async, a Deferred is returned instead.
         """
 

--- a/vumi_message_store/interfaces.py
+++ b/vumi_message_store/interfaces.py
@@ -264,13 +264,19 @@ class IQueryMessageStore(Interface):
             If async, a Deferred is returned instead.
         """
 
-    def list_message_events(message_id):
+    def list_message_events(message_id, start=None, end=None):
         """
         List event keys with timestamps and statuses for the given outbound
         message.
 
         :param message_id:
             The message identifier to find events for.
+
+        :param start:
+            Timestamp denoting the start of a range query.
+
+        :param end:
+            Timestamp denoting the end of a range query.
 
         :returns:
             An IndexPage object containing a list tupled of event key,

--- a/vumi_message_store/interfaces.py
+++ b/vumi_message_store/interfaces.py
@@ -224,85 +224,7 @@ class IQueryMessageStore(Interface):
             If async, a Deferred is returned instead.
         """
 
-    def list_batch_inbound_keys(batch_id, max_results=None, continuation=None):
-        """
-        List inbound message keys for the given batch.
-
-        :param batch_id:
-            The batch identifier for the batch to operate on.
-
-        :returns:
-            An IndexPage object containing a list of inbound message keys.
-            If async, a Deferred is returned instead.
-        """
-
-    def list_batch_outbound_keys(batch_id, max_results=None,
-                                 continuation=None):
-        """
-        List outbound message keys for the given batch.
-
-        :param batch_id:
-            The batch identifier for the batch to operate on.
-
-        :returns:
-            An IndexPage object containing a list of outbound message keys.
-            If async, a Deferred is returned instead.
-        """
-
-    def list_message_event_keys(message_id, max_results=None,
-                                continuation=None):
-        """
-        List event keys for the given outbound message.
-
-        :param message_id:
-            The message identifier to find events for.
-
-        :returns:
-            An IndexPage object containing a list of event keys.
-            If async, a Deferred is returned instead.
-        """
-
-    def list_batch_inbound_keys_with_timestamps(batch_id, start=None,
-                                                end=None):
-        """
-        List inbound message keys with timestamps for the given batch.
-
-        :param batch_id:
-            The batch identifier for the batch to operate on.
-
-        :param start:
-            Timestamp denoting the start of a range query.
-
-        :param end:
-            Timestamp denoting the end of a range query.
-
-        :returns:
-            An IndexPage object containing a list of tuples of inbound message
-            key and timestamp.
-            If async, a Deferred is returned instead.
-        """
-
-    def list_batch_outbound_keys_with_timestamps(batch_id, start=None,
-                                                 end=None):
-        """
-        List outbound message keys with timestamps for the given batch.
-
-        :param batch_id:
-            The batch identifier for the batch to operate on.
-
-        :param start:
-            Timestamp denoting the start of a range query.
-
-        :param end:
-            Timestamp denoting the end of a range query.
-
-        :returns:
-            An IndexPage object containing a list of tuples of outbound message
-            key and timestamp.
-            If async, a Deferred is returned instead.
-        """
-
-    def list_batch_inbound_keys_with_addresses(batch_id, start=None, end=None):
+    def list_batch_inbound_messages(batch_id, start=None, end=None):
         """
         List inbound message keys with timestamps and source addresses for the
         given batch.
@@ -322,8 +244,7 @@ class IQueryMessageStore(Interface):
             If async, a Deferred is returned instead.
         """
 
-    def list_batch_outbound_keys_with_addresses(batch_id, start=None,
-                                                end=None):
+    def list_batch_outbound_messages(batch_id, start=None, end=None):
         """
         List outbound message keys with timestamps and destination addresses
         for the given batch.
@@ -343,7 +264,7 @@ class IQueryMessageStore(Interface):
             If async, a Deferred is returned instead.
         """
 
-    def list_message_event_keys_with_statuses(message_id):
+    def list_message_events(message_id):
         """
         List event keys with timestamps and statuses for the given outbound
         message.

--- a/vumi_message_store/message_store.py
+++ b/vumi_message_store/message_store.py
@@ -186,13 +186,14 @@ class QueryMessageStore(object):
         return self.riak_backend.list_batch_outbound_messages(
             batch_id, start=start, end=end, max_results=max_results)
 
-    def list_message_events(self, message_id, max_results=None):
+    def list_message_events(self, message_id, start=None, end=None,
+                            max_results=None):
         """
         List event keys with timestamps and statuses for the given outbound
         message.
         """
         return self.riak_backend.list_message_events(
-            message_id, max_results=max_results)
+            message_id, start=start, end=end, max_results=max_results)
 
     def list_batch_events(self, batch_id, start=None, end=None,
                           max_results=None):

--- a/vumi_message_store/message_store.py
+++ b/vumi_message_store/message_store.py
@@ -168,71 +168,30 @@ class QueryMessageStore(object):
         """
         return self.riak_backend.get_event(event_id)
 
-    def list_batch_inbound_keys(self, batch_id, max_results=None,
-                                continuation=None):
-        """
-        List inbound message keys for the given batch.
-        """
-        return self.riak_backend.list_batch_inbound_keys(
-            batch_id, max_results=max_results, continuation=continuation)
-
-    def list_batch_outbound_keys(self, batch_id, max_results=None,
-                                 continuation=None):
-        """
-        List outbound message keys for the given batch.
-        """
-        return self.riak_backend.list_batch_outbound_keys(
-            batch_id, max_results=max_results, continuation=continuation)
-
-    def list_message_event_keys(self, message_id, max_results=None,
-                                continuation=None):
-        """
-        List event keys for the given outbound message.
-        """
-        return self.riak_backend.list_message_event_keys(
-            message_id, max_results=max_results, continuation=continuation)
-
-    def list_batch_inbound_keys_with_timestamps(self, batch_id, start=None,
-                                                end=None, max_results=None):
-        """
-        List inbound message keys with timestamps for the given batch.
-        """
-        return self.riak_backend.list_batch_inbound_keys_with_timestamps(
-            batch_id, start=start, end=end, max_results=max_results)
-
-    def list_batch_outbound_keys_with_timestamps(self, batch_id, start=None,
-                                                 end=None, max_results=None):
-        """
-        List outbound message keys with timestamps for the given batch.
-        """
-        return self.riak_backend.list_batch_outbound_keys_with_timestamps(
-            batch_id, start=start, end=end, max_results=max_results)
-
-    def list_batch_inbound_keys_with_addresses(self, batch_id, start=None,
-                                               end=None, max_results=None):
+    def list_batch_inbound_messages(self, batch_id, start=None, end=None,
+                                    max_results=None):
         """
         List inbound message keys with timestamps and addresses in descending
         timestamp order for the given batch.
         """
-        return self.riak_backend.list_batch_inbound_keys_with_addresses(
+        return self.riak_backend.list_batch_inbound_messages(
             batch_id, start=start, end=end, max_results=max_results)
 
-    def list_batch_outbound_keys_with_addresses(self, batch_id, start=None,
-                                                end=None, max_results=None):
+    def list_batch_outbound_messages(self, batch_id, start=None, end=None,
+                                     max_results=None):
         """
         List outbound message keys with timestamps and addresses in descending
         timestamp order for the given batch.
         """
-        return self.riak_backend.list_batch_outbound_keys_with_addresses(
+        return self.riak_backend.list_batch_outbound_messages(
             batch_id, start=start, end=end, max_results=max_results)
 
-    def list_message_event_keys_with_statuses(self, message_id,
-                                              max_results=None):
+    def list_message_events(self, message_id, max_results=None):
         """
         List event keys with timestamps and statuses for the given outbound
         message.
         """
-        return self.riak_backend.list_message_event_keys_with_statuses(
+        return self.riak_backend.list_message_events(
             message_id, max_results=max_results)
 
     def list_batch_events(self, batch_id, start=None, end=None,
@@ -241,10 +200,8 @@ class QueryMessageStore(object):
         List event keys with timestamps and statuses for the given outbound
         message.
         """
-        return self.riak_backend.list_batch_events(batch_id,
-                                                   start=start,
-                                                   end=end,
-                                                   max_results=max_results)
+        return self.riak_backend.list_batch_events(
+            batch_id, start=start, end=end, max_results=max_results)
 
     def get_batch_info_status(self, batch_id):
         """

--- a/vumi_message_store/message_store.py
+++ b/vumi_message_store/message_store.py
@@ -169,40 +169,40 @@ class QueryMessageStore(object):
         return self.riak_backend.get_event(event_id)
 
     def list_batch_inbound_messages(self, batch_id, start=None, end=None,
-                                    max_results=None):
+                                    page_size=None):
         """
         List inbound message keys with timestamps and addresses in descending
         timestamp order for the given batch.
         """
         return self.riak_backend.list_batch_inbound_messages(
-            batch_id, start=start, end=end, max_results=max_results)
+            batch_id, start=start, end=end, page_size=page_size)
 
     def list_batch_outbound_messages(self, batch_id, start=None, end=None,
-                                     max_results=None):
+                                     page_size=None):
         """
         List outbound message keys with timestamps and addresses in descending
         timestamp order for the given batch.
         """
         return self.riak_backend.list_batch_outbound_messages(
-            batch_id, start=start, end=end, max_results=max_results)
+            batch_id, start=start, end=end, page_size=page_size)
 
     def list_message_events(self, message_id, start=None, end=None,
-                            max_results=None):
+                            page_size=None):
         """
         List event keys with timestamps and statuses in ascending timestamp
         order for the given outbound message.
         """
         return self.riak_backend.list_message_events(
-            message_id, start=start, end=end, max_results=max_results)
+            message_id, start=start, end=end, page_size=page_size)
 
     def list_batch_events(self, batch_id, start=None, end=None,
-                          max_results=None):
+                          page_size=None):
         """
         List event keys with timestamps and statuses in descending timestamp
         order for the given batch.
         """
         return self.riak_backend.list_batch_events(
-            batch_id, start=start, end=end, max_results=max_results)
+            batch_id, start=start, end=end, page_size=page_size)
 
     def get_batch_info_status(self, batch_id):
         """

--- a/vumi_message_store/message_store.py
+++ b/vumi_message_store/message_store.py
@@ -189,8 +189,8 @@ class QueryMessageStore(object):
     def list_message_events(self, message_id, start=None, end=None,
                             max_results=None):
         """
-        List event keys with timestamps and statuses for the given outbound
-        message.
+        List event keys with timestamps and statuses in ascending timestamp
+        order for the given outbound message.
         """
         return self.riak_backend.list_message_events(
             message_id, start=start, end=end, max_results=max_results)
@@ -198,8 +198,8 @@ class QueryMessageStore(object):
     def list_batch_events(self, batch_id, start=None, end=None,
                           max_results=None):
         """
-        List event keys with timestamps and statuses for the given outbound
-        message.
+        List event keys with timestamps and statuses in descending timestamp
+        order for the given batch.
         """
         return self.riak_backend.list_batch_events(
             batch_id, start=start, end=end, max_results=max_results)

--- a/vumi_message_store/riak_backend.py
+++ b/vumi_message_store/riak_backend.py
@@ -23,7 +23,7 @@ class MessageStoreRiakBackend(object):
     """
 
     # The Python Riak client defaults to max_results=1000 in places.
-    DEFAULT_MAX_RESULTS = 1000
+    DEFAULT_PAGE_SIZE = 1000
 
     def __init__(self, manager):
         self.manager = manager
@@ -202,68 +202,68 @@ class MessageStoreRiakBackend(object):
 
     @Manager.calls_manager
     def list_batch_inbound_messages(self, batch_id, start=None, end=None,
-                                    max_results=None):
+                                    page_size=None):
         """
         List inbound message keys with timestamps and addresses in descending
         timestamp order for the given batch.
         """
-        if max_results is None:
-            max_results = self.DEFAULT_MAX_RESULTS
+        if page_size is None:
+            page_size = self.DEFAULT_PAGE_SIZE
         start_range, end_range = (
             self._start_end_range_reverse(batch_id, start, end))
         results = yield self.inbound_messages.index_keys_page(
             'batches_with_addresses_reverse', start_range, end_range,
-            return_terms=True, max_results=max_results)
+            return_terms=True, max_results=page_size)
         returnValue(IndexPageWrapper(
             key_with_rts_and_value_formatter, self, batch_id, results))
 
     @Manager.calls_manager
     def list_batch_outbound_messages(self, batch_id, start=None, end=None,
-                                     max_results=None):
+                                     page_size=None):
         """
         List outbound message keys with timestamps and addresses in descending
         timestamp order for the given batch.
         """
-        if max_results is None:
-            max_results = self.DEFAULT_MAX_RESULTS
+        if page_size is None:
+            page_size = self.DEFAULT_PAGE_SIZE
         start_range, end_range = (
             self._start_end_range_reverse(batch_id, start, end))
         results = yield self.outbound_messages.index_keys_page(
             'batches_with_addresses_reverse', start_range, end_range,
-            return_terms=True, max_results=max_results)
+            return_terms=True, max_results=page_size)
         returnValue(IndexPageWrapper(
             key_with_rts_and_value_formatter, self, batch_id, results))
 
     @Manager.calls_manager
     def list_message_events(self, message_id, start=None, end=None,
-                            max_results=None):
+                            page_size=None):
         """
         List event keys with timestamps and statuses in ascending timestamp
         order for the given outbound message.
         """
-        if max_results is None:
-            max_results = self.DEFAULT_MAX_RESULTS
+        if page_size is None:
+            page_size = self.DEFAULT_PAGE_SIZE
         start_value, end_value = self._start_end_range(message_id, start, end)
         results = yield self.events.index_keys_page(
             'message_with_status', start_value, end_value, return_terms=True,
-            max_results=max_results)
+            max_results=page_size)
         returnValue(IndexPageWrapper(
             key_with_ts_and_value_formatter, self, message_id, results))
 
     @Manager.calls_manager
     def list_batch_events(self, batch_id, start=None, end=None,
-                          max_results=None):
+                          page_size=None):
         """
         List event keys with timestamps and statuses in descending timestamp
         order for the given batch.
         """
-        if max_results is None:
-            max_results = self.DEFAULT_MAX_RESULTS
+        if page_size is None:
+            page_size = self.DEFAULT_PAGE_SIZE
         start_range, end_range = (
             self._start_end_range_reverse(batch_id, start, end))
         results = yield self.events.index_keys_page(
             'batches_with_statuses_reverse', start_range, end_range,
-            return_terms=True, max_results=max_results)
+            return_terms=True, max_results=page_size)
         returnValue(IndexPageWrapper(
             key_with_rts_and_value_formatter, self, batch_id, results))
 

--- a/vumi_message_store/riak_backend.py
+++ b/vumi_message_store/riak_backend.py
@@ -177,39 +177,6 @@ class MessageStoreRiakBackend(object):
         event = yield self.get_raw_event(event_id)
         returnValue(event.event if event is not None else None)
 
-    def list_batch_inbound_keys(self, batch_id, max_results=None,
-                                continuation=None):
-        """
-        List inbound message keys for the given batch.
-        """
-        if max_results is None:
-            max_results = self.DEFAULT_MAX_RESULTS
-        return self.inbound_messages.index_keys_page(
-            'batches', batch_id, max_results=max_results,
-            continuation=continuation)
-
-    def list_batch_outbound_keys(self, batch_id, max_results=None,
-                                 continuation=None):
-        """
-        List outbound message keys for the given batch.
-        """
-        if max_results is None:
-            max_results = self.DEFAULT_MAX_RESULTS
-        return self.outbound_messages.index_keys_page(
-            'batches', batch_id, max_results=max_results,
-            continuation=continuation)
-
-    def list_message_event_keys(self, message_id, max_results=None,
-                                continuation=None):
-        """
-        List event keys for the given outbound message.
-        """
-        if max_results is None:
-            max_results = self.DEFAULT_MAX_RESULTS
-        return self.events.index_keys_page(
-            'message', message_id, max_results=max_results,
-            continuation=continuation)
-
     def _start_end_range(self, batch_id, start, end):
         if start is not None:
             start_value = "%s$%s" % (batch_id, start)
@@ -234,40 +201,8 @@ class MessageStoreRiakBackend(object):
         return self._start_end_range(batch_id, start, end)
 
     @Manager.calls_manager
-    def list_batch_inbound_keys_with_timestamps(self, batch_id, start=None,
-                                                end=None, max_results=None):
-        """
-        List inbound message keys with timestamps for the given batch.
-        """
-        if max_results is None:
-            max_results = self.DEFAULT_MAX_RESULTS
-        start_range, end_range = (
-            self._start_end_range_reverse(batch_id, start, end))
-        results = yield self.inbound_messages.index_keys_page(
-            'batches_with_addresses_reverse', start_range, end_range,
-            return_terms=True, max_results=max_results)
-        returnValue(IndexPageWrapper(
-            key_with_rts_only_formatter, self, batch_id, results))
-
-    @Manager.calls_manager
-    def list_batch_outbound_keys_with_timestamps(self, batch_id, start=None,
-                                                 end=None, max_results=None):
-        """
-        List outbound message keys with timestamps for the given batch.
-        """
-        if max_results is None:
-            max_results = self.DEFAULT_MAX_RESULTS
-        start_range, end_range = (
-            self._start_end_range_reverse(batch_id, start, end))
-        results = yield self.outbound_messages.index_keys_page(
-            'batches_with_addresses_reverse', start_range, end_range,
-            return_terms=True, max_results=max_results)
-        returnValue(IndexPageWrapper(
-            key_with_rts_only_formatter, self, batch_id, results))
-
-    @Manager.calls_manager
-    def list_batch_inbound_keys_with_addresses(self, batch_id, start=None,
-                                               end=None, max_results=None):
+    def list_batch_inbound_messages(self, batch_id, start=None, end=None,
+                                    max_results=None):
         """
         List inbound message keys with timestamps and addresses in descending
         timestamp order for the given batch.
@@ -283,8 +218,8 @@ class MessageStoreRiakBackend(object):
             key_with_rts_and_value_formatter, self, batch_id, results))
 
     @Manager.calls_manager
-    def list_batch_outbound_keys_with_addresses(self, batch_id, start=None,
-                                                end=None, max_results=None):
+    def list_batch_outbound_messages(self, batch_id, start=None, end=None,
+                                     max_results=None):
         """
         List outbound message keys with timestamps and addresses in descending
         timestamp order for the given batch.
@@ -300,8 +235,7 @@ class MessageStoreRiakBackend(object):
             key_with_rts_and_value_formatter, self, batch_id, results))
 
     @Manager.calls_manager
-    def list_message_event_keys_with_statuses(self, message_id,
-                                              max_results=None):
+    def list_message_events(self, message_id, max_results=None):
         """
         List event keys with timestamps and statuses for the given outbound
         message.
@@ -405,8 +339,3 @@ def key_with_ts_and_value_formatter(batch_id, result):
 def key_with_rts_and_value_formatter(batch_id, result):
     key, reverse_ts, value = key_with_ts_and_value_formatter(batch_id, result)
     return (key, from_reverse_timestamp(reverse_ts), value)
-
-
-def key_with_rts_only_formatter(batch_id, result):
-    key, reverse_ts, value = key_with_ts_and_value_formatter(batch_id, result)
-    return (key, from_reverse_timestamp(reverse_ts))

--- a/vumi_message_store/riak_backend.py
+++ b/vumi_message_store/riak_backend.py
@@ -238,8 +238,8 @@ class MessageStoreRiakBackend(object):
     def list_message_events(self, message_id, start=None, end=None,
                             max_results=None):
         """
-        List event keys with timestamps and statuses for the given outbound
-        message.
+        List event keys with timestamps and statuses in ascending timestamp
+        order for the given outbound message.
         """
         if max_results is None:
             max_results = self.DEFAULT_MAX_RESULTS
@@ -254,8 +254,8 @@ class MessageStoreRiakBackend(object):
     def list_batch_events(self, batch_id, start=None, end=None,
                           max_results=None):
         """
-        List event keys with timestamps and statuses for the given outbound
-        message.
+        List event keys with timestamps and statuses in descending timestamp
+        order for the given batch.
         """
         if max_results is None:
             max_results = self.DEFAULT_MAX_RESULTS

--- a/vumi_message_store/riak_backend.py
+++ b/vumi_message_store/riak_backend.py
@@ -235,14 +235,15 @@ class MessageStoreRiakBackend(object):
             key_with_rts_and_value_formatter, self, batch_id, results))
 
     @Manager.calls_manager
-    def list_message_events(self, message_id, max_results=None):
+    def list_message_events(self, message_id, start=None, end=None,
+                            max_results=None):
         """
         List event keys with timestamps and statuses for the given outbound
         message.
         """
         if max_results is None:
             max_results = self.DEFAULT_MAX_RESULTS
-        start_value, end_value = self._start_end_range(message_id, None, None)
+        start_value, end_value = self._start_end_range(message_id, start, end)
         results = yield self.events.index_keys_page(
             'message_with_status', start_value, end_value, return_terms=True,
             max_results=max_results)

--- a/vumi_message_store/tests/test_message_store.py
+++ b/vumi_message_store/tests/test_message_store.py
@@ -697,7 +697,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
         keys_p1 = yield self.store.list_batch_inbound_messages(
-            batch_id, max_results=3)
+            batch_id, page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[:3])
 
@@ -713,7 +713,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
         keys_p1 = yield self.store.list_batch_inbound_messages(
-            batch_id, start=all_keys[-2][1], max_results=3)
+            batch_id, start=all_keys[-2][1], page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[0:3])
 
@@ -729,7 +729,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
         keys_p1 = yield self.store.list_batch_inbound_messages(
-            batch_id, end=all_keys[1][1], max_results=3)
+            batch_id, end=all_keys[1][1], page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:4])
 
@@ -745,7 +745,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
         keys_p1 = yield self.store.list_batch_inbound_messages(
-            batch_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
+            batch_id, start=all_keys[-2][1], end=all_keys[1][1], page_size=2)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:3])
 
@@ -772,7 +772,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
         keys_p1 = yield self.store.list_batch_outbound_messages(
-            batch_id, max_results=3)
+            batch_id, page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[:3])
 
@@ -788,7 +788,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
         keys_p1 = yield self.store.list_batch_outbound_messages(
-            batch_id, start=all_keys[-2][1], max_results=3)
+            batch_id, start=all_keys[-2][1], page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[0:3])
 
@@ -804,7 +804,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
         keys_p1 = yield self.store.list_batch_outbound_messages(
-            batch_id, end=all_keys[1][1], max_results=3)
+            batch_id, end=all_keys[1][1], page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:4])
 
@@ -820,8 +820,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
         keys_p1 = yield self.store.list_batch_outbound_messages(
-            batch_id, start=all_keys[-2][1], end=all_keys[1][1],
-            max_results=2)
+            batch_id, start=all_keys[-2][1], end=all_keys[1][1], page_size=2)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:3])
 
@@ -848,7 +847,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
 
-        keys_p1 = yield self.store.list_message_events(msg_id, max_results=3)
+        keys_p1 = yield self.store.list_message_events(msg_id, page_size=3)
         # Paginated results are sorted by ascending timestamp.
         all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[:3])
@@ -865,7 +864,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
         keys_p1 = yield self.store.list_message_events(
-            msg_id, start=all_keys[-2][1], max_results=3)
+            msg_id, start=all_keys[-2][1], page_size=3)
         # Paginated results are sorted by ascending timestamp.
         all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[1:4])
@@ -882,7 +881,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
         keys_p1 = yield self.store.list_message_events(
-            msg_id, end=all_keys[1][1], max_results=3)
+            msg_id, end=all_keys[1][1], page_size=3)
         # Paginated results are sorted by ascending timestamp.
         all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[0:3])
@@ -899,7 +898,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
         keys_p1 = yield self.store.list_message_events(
-            msg_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
+            msg_id, start=all_keys[-2][1], end=all_keys[1][1], page_size=2)
         # Paginated results are sorted by ascending timestamp.
         all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[1:3])
@@ -1138,7 +1137,7 @@ class TestQueryMessageStore(VumiTestCase):
         """
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
-        keys_p1 = yield self.store.list_batch_events(batch_id, max_results=3)
+        keys_p1 = yield self.store.list_batch_events(batch_id, page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[:3])
 
@@ -1154,7 +1153,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
         keys_p1 = yield self.store.list_batch_events(
-            batch_id, start=all_keys[-2][1], max_results=3)
+            batch_id, start=all_keys[-2][1], page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[0:3])
 
@@ -1170,7 +1169,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
         keys_p1 = yield self.store.list_batch_events(
-            batch_id, end=all_keys[1][1], max_results=3)
+            batch_id, end=all_keys[1][1], page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:4])
 
@@ -1186,7 +1185,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
         keys_p1 = yield self.store.list_batch_events(
-            batch_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
+            batch_id, start=all_keys[-2][1], end=all_keys[1][1], page_size=2)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:3])
 

--- a/vumi_message_store/tests/test_message_store.py
+++ b/vumi_message_store/tests/test_message_store.py
@@ -690,9 +690,9 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_inbound_messages(self):
         """
-        When we ask for a list of inbound message keys with addresses, we get
-        an IndexPageWrapper containing the first page of results and can ask
-        for following pages until all results are delivered.
+        When we ask for a list of inbound messages for a batch, we get an
+        IndexPageWrapper containing the first page of results and can ask for
+        following pages until all results are delivered.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
@@ -707,8 +707,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_inbound_messages_range_start(self):
         """
-        When we ask for a list of inbound message keys with addresses, we can
-        specify a start timestamp.
+        When we ask for a list of inbound messages for a batch, we can specify
+        a start timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
@@ -723,8 +723,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_inbound_messages_range_end(self):
         """
-        When we ask for a list of inbound message keys with addresses, we can
-        specify an end timestamp.
+        When we ask for a list of inbound messages for a batch, we can specify
+        an end timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
@@ -739,8 +739,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_inbound_messages_range(self):
         """
-        When we ask for a list of inbound message keys with addresses, we can
-        specify both ends of the range.
+        When we ask for a list of inbound messages for a batch, we can specify
+        both ends of the range.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
@@ -755,8 +755,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_inbound_messages_empty(self):
         """
-        When we ask for a list of inbound message keys with addresses for an
-        empty batch, we get an empty IndexPageWrapper.
+        When we ask for a list of inbound messages for an empty batch, we get
+        an empty IndexPageWrapper.
         """
         batch_id = yield self.backend.batch_start()
         keys_page = yield self.store.list_batch_inbound_messages(batch_id)
@@ -765,9 +765,9 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_outbound_messages(self):
         """
-        When we ask for a list of outbound message keys with addresses, we get
-        an IndexPageWrapper containing the first page of results and can ask
-        for following pages until all results are delivered.
+        When we ask for a list of outbound messages for a batch, we get an
+        IndexPageWrapper containing the first page of results and can ask for
+        following pages until all results are delivered.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
@@ -782,8 +782,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_outbound_messages_range_start(self):
         """
-        When we ask for a list of outbound message keys with addresses, we can
-        specify a start timestamp.
+        When we ask for a list of outbound messages for a batch, we can specify
+        a start timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
@@ -798,8 +798,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_outbound_messages_range_end(self):
         """
-        When we ask for a list of outbound message keys with addresses, we can
-        specify an end timestamp.
+        When we ask for a list of outbound messages for a batch, we can specify
+        an end timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
@@ -814,8 +814,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_outbound_messages_range(self):
         """
-        When we ask for a list of outbound message keys with addresses, we can
-        specify both ends of the range.
+        When we ask for a list of outbound messages for a batch, we can specify
+        both ends of the range.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
@@ -831,8 +831,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_outbound_messages_empty(self):
         """
-        When we ask for a list of outbound message keys with addresses for an
-        empty batch, we get an empty IndexPageWrapper.
+        When we ask for a list of outbound messages for an empty batch, we get
+        an empty IndexPageWrapper.
         """
         batch_id = yield self.backend.batch_start()
         keys_page = yield self.store.list_batch_outbound_messages(batch_id)
@@ -841,7 +841,7 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_message_events(self):
         """
-        When we ask for a list of event keys with statuses, we get an
+        When we ask for a list of events for an outbound message, we get an
         IndexPageWrapper containing the first page of results and can ask for
         following pages until all results are delivered.
         """
@@ -859,8 +859,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_message_events_range_start(self):
         """
-        When we ask for a list of event keys for a message, we can specify a
-        start timestamp.
+        When we ask for a list of event keys for an outbound message, we can
+        specify a start timestamp.
         """
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
@@ -876,8 +876,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_message_events_range_end(self):
         """
-        When we ask for a list of event keys for a message, we can specify an
-        end timestamp.
+        When we ask for a list of event keys for an outbound message, we can
+        specify an end timestamp.
         """
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
@@ -893,8 +893,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_message_events_range(self):
         """
-        When we ask for a list of event keys for a message, we can specify both
-        ends of the range.
+        When we ask for a list of event keys for an outbound message, we can
+        specify both ends of the range.
         """
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
@@ -910,8 +910,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_message_events_empty(self):
         """
-        When we ask for a list of event keys with statuses for a message with
-        no events, we get an empty IndexPageWrapper.
+        When we ask for a list of events for an outbound message with no
+        events, we get an empty IndexPageWrapper.
         """
         batch_id = yield self.backend.batch_start()
         msg = self.msg_helper.make_outbound("hello")
@@ -922,8 +922,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_message_events_no_message(self):
         """
-        When we ask for a list of event keys with statuses for a message that
-        does not exist, we get an empty IndexPageWrapper.
+        When we ask for a list of events for an outbound message that does not
+        exist, we get an empty IndexPageWrapper.
         """
         keys_page = yield self.store.list_message_events("badmsg")
         self.assertEqual(list(keys_page), [])
@@ -1132,7 +1132,7 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_events(self):
         """
-        When we ask for a list of event keys for a batch, we get an
+        When we ask for a list of events for a batch, we get an
         IndexPageWrapper containing the first page of results and can ask for
         following pages until all results are delivered.
         """
@@ -1148,8 +1148,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_events_range_start(self):
         """
-        When we ask for a list of event keys for a batch, we can specify a
-        start timestamp.
+        When we ask for a list of events for a batch, we can specify a start
+        timestamp.
         """
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
@@ -1164,7 +1164,7 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_events_range_end(self):
         """
-        When we ask for a list of event keys for a batch, we can specify an end
+        When we ask for a list of events for a batch, we can specify an end
         timestamp.
         """
         batch_id, msg_id, all_keys = (
@@ -1180,8 +1180,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_events_range(self):
         """
-        When we ask for a list of event keys for a batch, we can specify both
-        ends of the range.
+        When we ask for a list of events for a batch, we can specify both ends
+        of the range.
         """
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
@@ -1196,8 +1196,8 @@ class TestQueryMessageStore(VumiTestCase):
     @inlineCallbacks
     def test_list_batch_events_empty(self):
         """
-        When we ask for a list of event keys for a batch for an empty batch, we
-        get an empty IndexPageWrapper.
+        When we ask for a list of events for an empty batch, we get an empty
+        IndexPageWrapper.
         """
         batch_id = yield self.backend.batch_start()
         keys_page = yield self.store.list_batch_events(batch_id)

--- a/vumi_message_store/tests/test_message_store.py
+++ b/vumi_message_store/tests/test_message_store.py
@@ -688,250 +688,7 @@ class TestQueryMessageStore(VumiTestCase):
         self.assertEqual(stored_record, None)
 
     @inlineCallbacks
-    def test_list_batch_inbound_keys(self):
-        """
-        When we ask for a list of inbound message keys, we get an IndexPage
-        containing the first page of results and can ask for following pages
-        until all results are delivered.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys = sorted(key for key, _, _ in all_keys)
-
-        keys_p1 = yield self.store.list_batch_inbound_keys(batch_id, 3)
-        # Paginated results are sorted by key.
-        self.assertEqual(sorted(keys_p1), all_keys[:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(sorted(keys_p2), all_keys[3:])
-
-    @inlineCallbacks
-    def test_list_batch_outbound_keys(self):
-        """
-        When we ask for a list of outbound message keys, we get an IndexPage
-        containing the first page of results and can ask for following pages
-        until all results are delivered.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys = sorted(key for key, _, _ in all_keys)
-
-        keys_p1 = yield self.store.list_batch_outbound_keys(batch_id, 3)
-        # Paginated results are sorted by key.
-        self.assertEqual(sorted(keys_p1), all_keys[:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(sorted(keys_p2), all_keys[3:])
-
-    @inlineCallbacks
-    def test_list_message_event_keys(self):
-        """
-        When we ask for a list of outbound message keys, we get an IndexPage
-        containing the first page of results and can ask for following pages
-        until all results are delivered.
-        """
-        batch_id, msg_id, all_keys = (
-            yield self.msg_seq_helper.create_ack_event_sequence())
-        all_keys = sorted(key for key, _, _ in all_keys)
-
-        keys_p1 = yield self.store.list_message_event_keys(msg_id, 3)
-        # Paginated results are sorted by key.
-        self.assertEqual(sorted(keys_p1), all_keys[:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(sorted(keys_p2), all_keys[3:])
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_with_timestamps(self):
-        """
-        When we ask for a list of inbound message keys with timestamps, we get
-        an IndexPageWrapper containing the first page of results and can ask
-        for following pages until all results are delivered.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.store.list_batch_inbound_keys_with_timestamps(
-            batch_id, max_results=3)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:])
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_length(self):
-        """
-        When we ask for a list of inbound message keys, we get an IndexPage
-        containing the first page of results of the requested page length and
-        can ask for the next page which contains the expected number of
-        remaining results.
-        """
-        batch_id, _ = (
-            yield self.msg_seq_helper.create_inbound_message_sequence(
-                msg_count=5))
-
-        keys_p1 = yield self.store.list_batch_inbound_keys(batch_id, 3)
-        self.assertEqual(len(keys_p1), 3)
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(len(keys_p2), 2)
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_empty_length(self):
-        """
-        When we ask for a list of inbound message keys before storing any
-        inbound messages for the batch, we get an IndexPage with length 0.
-        """
-        batch_id = yield self.backend.batch_start()
-
-        keys_p1 = yield self.store.list_batch_inbound_keys(batch_id, 3)
-        self.assertEqual(len(keys_p1), 0)
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_with_timestamps_range_start(self):
-        """
-        When we ask for a list of inbound message keys with timestamps, we can
-        specify a start timestamp.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.store.list_batch_inbound_keys_with_timestamps(
-            batch_id, start=all_keys[-2][1], max_results=3)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[0:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:-1])
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_with_timestamps_range_end(self):
-        """
-        When we ask for a list of inbound message keys with timestamps, we can
-        specify an end timestamp.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.store.list_batch_inbound_keys_with_timestamps(
-            batch_id, end=all_keys[1][1], max_results=3)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[1:4])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[4:])
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_with_timestamps_range(self):
-        """
-        When we ask for a list of inbound message keys with timestamps, we can
-        specify both ends of the range.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.store.list_batch_inbound_keys_with_timestamps(
-            batch_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[1:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:-1])
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_with_timestamps_empty(self):
-        """
-        When we ask for a list of inbound message keys with timestamps for an
-        empty batch, we get an empty IndexPageWrapper.
-        """
-        batch_id = yield self.backend.batch_start()
-        keys_page = yield self.store.list_batch_inbound_keys_with_timestamps(
-            batch_id)
-        self.assertEqual(list(keys_page), [])
-
-    @inlineCallbacks
-    def test_list_batch_outbound_keys_with_timestamps(self):
-        """
-        When we ask for a list of outbound message keys with timestamps, we get
-        an IndexPageWrapper containing the first page of results and can ask
-        for following pages until all results are delivered.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.store.list_batch_outbound_keys_with_timestamps(
-            batch_id, max_results=3)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:])
-
-    @inlineCallbacks
-    def test_list_batch_outbound_keys_with_timestamps_range_start(self):
-        """
-        When we ask for a list of outbound message keys with timestamps, we can
-        specify a start timestamp.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.store.list_batch_outbound_keys_with_timestamps(
-            batch_id, start=all_keys[-2][1], max_results=3)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[0:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:-1])
-
-    @inlineCallbacks
-    def test_list_batch_outbound_keys_with_timestamps_range_end(self):
-        """
-        When we ask for a list of outbound message keys with timestamps, we can
-        specify an end timestamp.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.store.list_batch_outbound_keys_with_timestamps(
-            batch_id, end=all_keys[1][1], max_results=3)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[1:4])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[4:])
-
-    @inlineCallbacks
-    def test_list_batch_outbound_keys_with_timestamps_range(self):
-        """
-        When we ask for a list of outbound message keys with timestamps, we can
-        specify both ends of the range.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.store.list_batch_outbound_keys_with_timestamps(
-            batch_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[1:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:-1])
-
-    @inlineCallbacks
-    def test_list_batch_outbound_keys_with_timestamps_empty(self):
-        """
-        When we ask for a list of outbound message keys with timestamps for an
-        empty batch, we get an empty IndexPageWrapper.
-        """
-        batch_id = yield self.backend.batch_start()
-        page = yield self.store.list_batch_outbound_keys_with_timestamps(
-            batch_id)
-        self.assertEqual(list(page), [])
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_with_addresses(self):
+    def test_list_batch_inbound_messages(self):
         """
         When we ask for a list of inbound message keys with addresses, we get
         an IndexPageWrapper containing the first page of results and can ask
@@ -939,7 +696,7 @@ class TestQueryMessageStore(VumiTestCase):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        keys_p1 = yield self.store.list_batch_inbound_keys_with_addresses(
+        keys_p1 = yield self.store.list_batch_inbound_messages(
             batch_id, max_results=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[:3])
@@ -948,14 +705,14 @@ class TestQueryMessageStore(VumiTestCase):
         self.assertEqual(list(keys_p2), all_keys[3:])
 
     @inlineCallbacks
-    def test_list_batch_inbound_keys_with_addresses_range_start(self):
+    def test_list_batch_inbound_messages_range_start(self):
         """
         When we ask for a list of inbound message keys with addresses, we can
         specify a start timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        keys_p1 = yield self.store.list_batch_inbound_keys_with_addresses(
+        keys_p1 = yield self.store.list_batch_inbound_messages(
             batch_id, start=all_keys[-2][1], max_results=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[0:3])
@@ -964,14 +721,14 @@ class TestQueryMessageStore(VumiTestCase):
         self.assertEqual(list(keys_p2), all_keys[3:-1])
 
     @inlineCallbacks
-    def test_list_batch_inbound_keys_with_addresses_range_end(self):
+    def test_list_batch_inbound_messages_range_end(self):
         """
         When we ask for a list of inbound message keys with addresses, we can
         specify an end timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        keys_p1 = yield self.store.list_batch_inbound_keys_with_addresses(
+        keys_p1 = yield self.store.list_batch_inbound_messages(
             batch_id, end=all_keys[1][1], max_results=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:4])
@@ -980,14 +737,14 @@ class TestQueryMessageStore(VumiTestCase):
         self.assertEqual(list(keys_p2), all_keys[4:])
 
     @inlineCallbacks
-    def test_list_batch_inbound_keys_with_addresses_range(self):
+    def test_list_batch_inbound_messages_range(self):
         """
         When we ask for a list of inbound message keys with addresses, we can
         specify both ends of the range.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        keys_p1 = yield self.store.list_batch_inbound_keys_with_addresses(
+        keys_p1 = yield self.store.list_batch_inbound_messages(
             batch_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:3])
@@ -996,18 +753,17 @@ class TestQueryMessageStore(VumiTestCase):
         self.assertEqual(list(keys_p2), all_keys[3:-1])
 
     @inlineCallbacks
-    def test_list_batch_inbound_keys_with_addresses_empty(self):
+    def test_list_batch_inbound_messages_empty(self):
         """
         When we ask for a list of inbound message keys with addresses for an
         empty batch, we get an empty IndexPageWrapper.
         """
         batch_id = yield self.backend.batch_start()
-        keys_page = yield self.store.list_batch_inbound_keys_with_addresses(
-            batch_id)
+        keys_page = yield self.store.list_batch_inbound_messages(batch_id)
         self.assertEqual(list(keys_page), [])
 
     @inlineCallbacks
-    def test_list_batch_outbound_keys_with_addresses(self):
+    def test_list_batch_outbound_messages(self):
         """
         When we ask for a list of outbound message keys with addresses, we get
         an IndexPageWrapper containing the first page of results and can ask
@@ -1015,7 +771,7 @@ class TestQueryMessageStore(VumiTestCase):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        keys_p1 = yield self.store.list_batch_outbound_keys_with_addresses(
+        keys_p1 = yield self.store.list_batch_outbound_messages(
             batch_id, max_results=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[:3])
@@ -1024,14 +780,14 @@ class TestQueryMessageStore(VumiTestCase):
         self.assertEqual(list(keys_p2), all_keys[3:])
 
     @inlineCallbacks
-    def test_list_batch_outbound_keys_with_addresses_range_start(self):
+    def test_list_batch_outbound_messages_range_start(self):
         """
         When we ask for a list of outbound message keys with addresses, we can
         specify a start timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        keys_p1 = yield self.store.list_batch_outbound_keys_with_addresses(
+        keys_p1 = yield self.store.list_batch_outbound_messages(
             batch_id, start=all_keys[-2][1], max_results=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[0:3])
@@ -1040,14 +796,14 @@ class TestQueryMessageStore(VumiTestCase):
         self.assertEqual(list(keys_p2), all_keys[3:-1])
 
     @inlineCallbacks
-    def test_list_batch_outbound_keys_with_addresses_range_end(self):
+    def test_list_batch_outbound_messages_range_end(self):
         """
         When we ask for a list of outbound message keys with addresses, we can
         specify an end timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        keys_p1 = yield self.store.list_batch_outbound_keys_with_addresses(
+        keys_p1 = yield self.store.list_batch_outbound_messages(
             batch_id, end=all_keys[1][1], max_results=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:4])
@@ -1056,14 +812,14 @@ class TestQueryMessageStore(VumiTestCase):
         self.assertEqual(list(keys_p2), all_keys[4:])
 
     @inlineCallbacks
-    def test_list_batch_outbound_keys_with_addresses_range(self):
+    def test_list_batch_outbound_messages_range(self):
         """
         When we ask for a list of outbound message keys with addresses, we can
         specify both ends of the range.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        keys_p1 = yield self.store.list_batch_outbound_keys_with_addresses(
+        keys_p1 = yield self.store.list_batch_outbound_messages(
             batch_id, start=all_keys[-2][1], end=all_keys[1][1],
             max_results=2)
         # Paginated results are sorted by descending timestamp.
@@ -1073,18 +829,17 @@ class TestQueryMessageStore(VumiTestCase):
         self.assertEqual(list(keys_p2), all_keys[3:-1])
 
     @inlineCallbacks
-    def test_list_batch_outbound_keys_with_addresses_empty(self):
+    def test_list_batch_outbound_messages_empty(self):
         """
         When we ask for a list of outbound message keys with addresses for an
         empty batch, we get an empty IndexPageWrapper.
         """
         batch_id = yield self.backend.batch_start()
-        keys_page = yield self.store.list_batch_outbound_keys_with_addresses(
-            batch_id)
+        keys_page = yield self.store.list_batch_outbound_messages(batch_id)
         self.assertEqual(list(keys_page), [])
 
     @inlineCallbacks
-    def test_list_message_event_keys_with_statuses(self):
+    def test_list_message_events(self):
         """
         When we ask for a list of event keys with statuses, we get an
         IndexPageWrapper containing the first page of results and can ask for
@@ -1093,8 +848,7 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
 
-        keys_p1 = yield self.store.list_message_event_keys_with_statuses(
-            msg_id, max_results=3)
+        keys_p1 = yield self.store.list_message_events(msg_id, max_results=3)
         # Paginated results are sorted by ascending timestamp.
         all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[:3])
@@ -1103,7 +857,7 @@ class TestQueryMessageStore(VumiTestCase):
         self.assertEqual(list(keys_p2), all_keys[3:])
 
     @inlineCallbacks
-    def test_list_message_event_keys_with_statuses_no_events(self):
+    def test_list_message_events_no_events(self):
         """
         When we ask for a list of event keys with statuses for a message with
         no events, we get an empty IndexPageWrapper.
@@ -1111,18 +865,16 @@ class TestQueryMessageStore(VumiTestCase):
         batch_id = yield self.backend.batch_start()
         msg = self.msg_helper.make_outbound("hello")
         yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
-        keys_page = yield self.store.list_message_event_keys_with_statuses(
-            msg["message_id"])
+        keys_page = yield self.store.list_message_events(msg["message_id"])
         self.assertEqual(list(keys_page), [])
 
     @inlineCallbacks
-    def test_list_message_event_keys_with_statuses_no_message(self):
+    def test_list_message_events_no_message(self):
         """
         When we ask for a list of event keys with statuses for a message that
         does not exist, we get an empty IndexPageWrapper.
         """
-        keys_page = yield self.store.list_message_event_keys_with_statuses(
-            "badmsg")
+        keys_page = yield self.store.list_message_events("badmsg")
         self.assertEqual(list(keys_page), [])
 
     @inlineCallbacks
@@ -1335,8 +1087,7 @@ class TestQueryMessageStore(VumiTestCase):
         """
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
-        keys_p1 = yield self.store.list_batch_events(
-            batch_id, max_results=3)
+        keys_p1 = yield self.store.list_batch_events(batch_id, max_results=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[:3])
 
@@ -1398,6 +1149,5 @@ class TestQueryMessageStore(VumiTestCase):
         get an empty IndexPageWrapper.
         """
         batch_id = yield self.backend.batch_start()
-        keys_page = yield self.store.list_batch_events(
-            batch_id)
+        keys_page = yield self.store.list_batch_events(batch_id)
         self.assertEqual(list(keys_page), [])

--- a/vumi_message_store/tests/test_riak_backend.py
+++ b/vumi_message_store/tests/test_riak_backend.py
@@ -687,9 +687,9 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_inbound_messages(self):
         """
-        When we ask for a list of inbound message keys with addresses, we get
-        an IndexPageWrapper containing the first page of results and can ask
-        for following pages until all results are delivered.
+        When we ask for a list of inbound messages for a batch, we get an
+        IndexPageWrapper containing the first page of results and can ask for
+        following pages until all results are delivered.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
@@ -704,8 +704,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_inbound_messages_range_start(self):
         """
-        When we ask for a list of inbound message keys with addresses, we can
-        specify a start timestamp.
+        When we ask for a list of inbound messages for a batch, we can specify
+        a start timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
@@ -720,8 +720,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_inbound_messages_range_end(self):
         """
-        When we ask for a list of inbound message keys with addresses, we can
-        specify an end timestamp.
+        When we ask for a list of inbound messages for a batch, we can specify
+        an end timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
@@ -736,8 +736,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_inbound_messages_range(self):
         """
-        When we ask for a list of inbound message keys with addresses, we can
-        specify both ends of the range.
+        When we ask for a list of inbound messages for a batch, we can specify
+        both ends of the range.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
@@ -752,8 +752,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_inbound_messages_empty(self):
         """
-        When we ask for a list of inbound message keys with addresses for an
-        empty batch, we get an empty IndexPageWrapper.
+        When we ask for a list of inbound messages for an empty batch, we get
+        an empty IndexPageWrapper.
         """
         batch_id = yield self.backend.batch_start()
         keys_page = yield self.backend.list_batch_inbound_messages(batch_id)
@@ -762,9 +762,9 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_outbound_messages(self):
         """
-        When we ask for a list of outbound message keys with addresses, we get
-        an IndexPageWrapper containing the first page of results and can ask
-        for following pages until all results are delivered.
+        When we ask for a list of outbound messages for a batch, we get an
+        IndexPageWrapper containing the first page of results and can ask for
+        following pages until all results are delivered.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
@@ -779,8 +779,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_outbound_messages_range_start(self):
         """
-        When we ask for a list of outbound message keys with addresses, we can
-        specify a start timestamp.
+        When we ask for a list of outbound messages for a batch, we can specify
+        a start timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
@@ -795,8 +795,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_outbound_messages_range_end(self):
         """
-        When we ask for a list of outbound message keys with addresses, we can
-        specify an end timestamp.
+        When we ask for a list of outbound messages for a batch, we can specify
+        an end timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
@@ -811,8 +811,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_outbound_messages_range(self):
         """
-        When we ask for a list of outbound message keys with addresses, we can
-        specify both ends of the range.
+        When we ask for a list of outbound messages for a batch, we can specify
+        both ends of the range.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
@@ -827,8 +827,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_outbound_messages_empty(self):
         """
-        When we ask for a list of outbound message keys with addresses for an
-        empty batch, we get an empty IndexPageWrapper.
+        When we ask for a list of outbound messages for an empty batch, we get
+        an empty IndexPageWrapper.
         """
         batch_id = yield self.backend.batch_start()
         keys_page = yield self.backend.list_batch_outbound_messages(batch_id)
@@ -837,7 +837,7 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_message_events(self):
         """
-        When we ask for a list of event keys with statuses, we get an
+        When we ask for a list of events for an outbound message, we get an
         IndexPageWrapper containing the first page of results and can ask for
         following pages until all results are delivered.
         """
@@ -855,8 +855,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_message_events_range_start(self):
         """
-        When we ask for a list of event keys for a message, we can specify a
-        start timestamp.
+        When we ask for a list of events for an outbound message, we can
+        specify a start timestamp.
         """
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
@@ -872,8 +872,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_message_events_range_end(self):
         """
-        When we ask for a list of event keys for a message, we can specify an
-        end timestamp.
+        When we ask for a list of events for an outbound message, we can
+        specify an end timestamp.
         """
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
@@ -889,8 +889,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_message_events_range(self):
         """
-        When we ask for a list of event keys for a message, we can specify both
-        ends of the range.
+        When we ask for a list of events for an outbound message, we can
+        specify both ends of the range.
         """
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
@@ -906,8 +906,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_message_events_empty(self):
         """
-        When we ask for a list of event keys with statuses for a message with
-        no events, we get an empty IndexPageWrapper.
+        When we ask for a list of events for an outbound message with no
+        events, we get an empty IndexPageWrapper.
         """
         batch_id = yield self.backend.batch_start()
         msg = self.msg_helper.make_outbound("hello")
@@ -918,8 +918,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_message_events_no_message(self):
         """
-        When we ask for a list of event keys with statuses for a message that
-        does not exist, we get an empty IndexPageWrapper.
+        When we ask for a list of events for an outbound message that does not
+        exist, we get an empty IndexPageWrapper.
         """
         keys_page = yield self.backend.list_message_events("badmsg")
         self.assertEqual(list(keys_page), [])
@@ -927,7 +927,7 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_events(self):
         """
-        When we ask for a list of event keys by for a batch, we get an
+        When we ask for a list of events for a batch, we get an
         IndexPageWrapper containing the first page of results and can ask for
         following pages until all results are delivered.
         """
@@ -943,8 +943,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_events_range_start(self):
         """
-        When we ask for a list of event keys for a batch, we can specify a
-        start timestamp.
+        When we ask for a list of events for a batch, we can specify a start
+        timestamp.
         """
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
@@ -959,7 +959,7 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_events_range_end(self):
         """
-        When we ask for a list of event keys for a batch, we can specify an end
+        When we ask for a list of events for a batch, we can specify an end
         timestamp.
         """
         batch_id, msg_id, all_keys = (
@@ -975,8 +975,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_events_range(self):
         """
-        When we ask for a list of event keys for a batch, we can specify both
-        ends of the range.
+        When we ask for a list of events for a batch, we can specify both ends
+        of the range.
         """
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
@@ -991,8 +991,8 @@ class RiakBackendTestMixin(object):
     @inlineCallbacks
     def test_list_batch_events_empty(self):
         """
-        When we ask for a list of event keys for an empty batch, we get an
-        empty IndexPageWrapper.
+        When we ask for a list of events for an empty batch, we get an empty
+        IndexPageWrapper.
         """
         batch_id = yield self.backend.batch_start()
         keys_page = yield self.backend.list_batch_events(batch_id)

--- a/vumi_message_store/tests/test_riak_backend.py
+++ b/vumi_message_store/tests/test_riak_backend.py
@@ -853,7 +853,58 @@ class RiakBackendTestMixin(object):
         self.assertEqual(list(keys_p2), all_keys[3:])
 
     @inlineCallbacks
-    def test_list_message_events_no_events(self):
+    def test_list_message_events_range_start(self):
+        """
+        When we ask for a list of event keys for a message, we can specify a
+        start timestamp.
+        """
+        batch_id, msg_id, all_keys = (
+            yield self.msg_seq_helper.create_ack_event_sequence())
+        keys_p1 = yield self.backend.list_message_events(
+            msg_id, start=all_keys[-2][1], max_results=3)
+        # Paginated results are sorted by ascending timestamp.
+        all_keys.reverse()
+        self.assertEqual(list(keys_p1), all_keys[1:4])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[4:])
+
+    @inlineCallbacks
+    def test_list_message_events_range_end(self):
+        """
+        When we ask for a list of event keys for a message, we can specify an
+        end timestamp.
+        """
+        batch_id, msg_id, all_keys = (
+            yield self.msg_seq_helper.create_ack_event_sequence())
+        keys_p1 = yield self.backend.list_message_events(
+            msg_id, end=all_keys[1][1], max_results=3)
+        # Paginated results are sorted by ascending timestamp.
+        all_keys.reverse()
+        self.assertEqual(list(keys_p1), all_keys[0:3])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[3:-1])
+
+    @inlineCallbacks
+    def test_list_message_events_range(self):
+        """
+        When we ask for a list of event keys for a message, we can specify both
+        ends of the range.
+        """
+        batch_id, msg_id, all_keys = (
+            yield self.msg_seq_helper.create_ack_event_sequence())
+        keys_p1 = yield self.backend.list_message_events(
+            msg_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
+        # Paginated results are sorted by ascending timestamp.
+        all_keys.reverse()
+        self.assertEqual(list(keys_p1), all_keys[1:3])
+
+        keys_p2 = yield keys_p1.next_page()
+        self.assertEqual(list(keys_p2), all_keys[3:-1])
+
+    @inlineCallbacks
+    def test_list_message_events_empty(self):
         """
         When we ask for a list of event keys with statuses for a message with
         no events, we get an empty IndexPageWrapper.

--- a/vumi_message_store/tests/test_riak_backend.py
+++ b/vumi_message_store/tests/test_riak_backend.py
@@ -685,266 +685,7 @@ class RiakBackendTestMixin(object):
         self.assertEqual(stored_record, None)
 
     @inlineCallbacks
-    def test_list_batch_inbound_keys(self):
-        """
-        When we ask for a list of inbound message keys, we get an IndexPage
-        containing the first page of results and can ask for following pages
-        until all results are delivered.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys = sorted(key for key, _, _ in all_keys)
-
-        keys_p1 = yield self.backend.list_batch_inbound_keys(batch_id, 3)
-        # Paginated results are sorted by key.
-        self.assertEqual(sorted(keys_p1), all_keys[:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(sorted(keys_p2), all_keys[3:])
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_empty(self):
-        """
-        When we ask for a list of inbound message keys for an empty batch, we
-        get an empty IndexPage.
-        """
-        batch_id = yield self.backend.batch_start()
-        keys_page = yield self.backend.list_batch_inbound_keys(batch_id)
-        self.assertEqual(list(keys_page), [])
-
-    @inlineCallbacks
-    def test_list_batch_outbound_keys(self):
-        """
-        When we ask for a list of outbound message keys, we get an IndexPage
-        containing the first page of results and can ask for following pages
-        until all results are delivered.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys = sorted(key for key, _, _ in all_keys)
-
-        keys_p1 = yield self.backend.list_batch_outbound_keys(batch_id, 3)
-        # Paginated results are sorted by key.
-        self.assertEqual(sorted(keys_p1), all_keys[:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(sorted(keys_p2), all_keys[3:])
-
-    @inlineCallbacks
-    def test_list_batch_outbound_keys_empty(self):
-        """
-        When we ask for a list of outbound message keys for an empty batch, we
-        get an empty IndexPage.
-        """
-        batch_id = yield self.backend.batch_start()
-        keys_page = yield self.backend.list_batch_outbound_keys(batch_id)
-        self.assertEqual(list(keys_page), [])
-
-    @inlineCallbacks
-    def test_list_message_event_keys(self):
-        """
-        When we ask for a list of outbound message keys, we get an IndexPage
-        containing the first page of results and can ask for following pages
-        until all results are delivered.
-        """
-        batch_id = yield self.backend.batch_start()
-        msg = self.msg_helper.make_outbound("pears")
-        yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
-        events = [
-            self.msg_helper.make_ack(msg),
-            self.msg_helper.make_delivery_report(msg),
-            self.msg_helper.make_delivery_report(msg),
-            self.msg_helper.make_delivery_report(msg),
-            self.msg_helper.make_delivery_report(msg),
-        ]
-        for event in events:
-            yield self.backend.add_event(event)
-        all_keys = sorted(event["event_id"] for event in events)
-
-        keys_p1 = yield self.backend.list_message_event_keys(
-            msg["message_id"], 3)
-        # Paginated results are sorted by key.
-        self.assertEqual(sorted(keys_p1), all_keys[:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(sorted(keys_p2), all_keys[3:])
-
-    @inlineCallbacks
-    def test_list_message_event_keys_empty(self):
-        """
-        When we ask for a list of event keys for a message with no events, we
-        get an empty IndexPage.
-        """
-        batch_id = yield self.backend.batch_start()
-        msg = self.msg_helper.make_outbound("pears")
-        yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
-
-        keys_page = yield self.backend.list_message_event_keys(
-            msg["message_id"])
-        self.assertEqual(list(keys_page), [])
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_with_timestamps(self):
-        """
-        When we ask for a list of inbound message keys with timestamps, we get
-        an IndexPageWrapper containing the first page of results and can ask
-        for following pages until all results are delivered.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.backend.list_batch_inbound_keys_with_timestamps(
-            batch_id, max_results=3)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:])
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_with_timestamps_range_start(self):
-        """
-        When we ask for a list of inbound message keys with timestamps, we can
-        specify a start timestamp.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.backend.list_batch_inbound_keys_with_timestamps(
-            batch_id, start=all_keys[-2][1], max_results=3)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[0:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:-1])
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_with_timestamps_range_end(self):
-        """
-        When we ask for a list of inbound message keys with timestamps, we can
-        specify an end timestamp.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.backend.list_batch_inbound_keys_with_timestamps(
-            batch_id, end=all_keys[1][1], max_results=3)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[1:4])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[4:])
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_with_timestamps_range(self):
-        """
-        When we ask for a list of inbound message keys with timestamps, we can
-        specify both ends of the range.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_inbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.backend.list_batch_inbound_keys_with_timestamps(
-            batch_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[1:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:-1])
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_with_timestamps_empty(self):
-        """
-        When we ask for a list of inbound message keys with timestamps for an
-        empty batch, we get an empty IndexPageWrapper.
-        """
-        batch_id = yield self.backend.batch_start()
-        keys_page = yield self.backend.list_batch_inbound_keys_with_timestamps(
-            batch_id)
-        self.assertEqual(list(keys_page), [])
-
-    @inlineCallbacks
-    def test_list_batch_outbound_keys_with_timestamps(self):
-        """
-        When we ask for a list of outbound message keys with timestamps, we get
-        an IndexPageWrapper containing the first page of results and can ask
-        for following pages until all results are delivered.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.backend.list_batch_outbound_keys_with_timestamps(
-            batch_id, max_results=3)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:])
-
-    @inlineCallbacks
-    def test_list_batch_outbound_keys_with_timestamps_range_start(self):
-        """
-        When we ask for a list of outbound message keys with timestamps, we can
-        specify a start timestamp.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.backend.list_batch_outbound_keys_with_timestamps(
-            batch_id, start=all_keys[-2][1], max_results=3)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[0:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:-1])
-
-    @inlineCallbacks
-    def test_list_batch_outbound_keys_with_timestamps_range_end(self):
-        """
-        When we ask for a list of outbound message keys with timestamps, we can
-        specify an end timestamp.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.backend.list_batch_outbound_keys_with_timestamps(
-            batch_id, end=all_keys[1][1], max_results=3)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[1:4])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[4:])
-
-    @inlineCallbacks
-    def test_list_batch_outbound_keys_with_timestamps_range(self):
-        """
-        When we ask for a list of outbound message keys with timestamps, we can
-        specify both ends of the range.
-        """
-        batch_id, all_keys = (
-            yield self.msg_seq_helper.create_outbound_message_sequence())
-        all_keys = [(key, ts) for key, ts, _ in all_keys]
-        keys_p1 = yield self.backend.list_batch_outbound_keys_with_timestamps(
-            batch_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
-        # Paginated results are sorted by descending timestamp.
-        self.assertEqual(list(keys_p1), all_keys[1:3])
-
-        keys_p2 = yield keys_p1.next_page()
-        self.assertEqual(list(keys_p2), all_keys[3:-1])
-
-    @inlineCallbacks
-    def test_list_batch_outbound_keys_with_timestamps_empty(self):
-        """
-        When we ask for a list of outbound message keys with timestamps for an
-        empty batch, we get an empty IndexPageWrapper.
-        """
-        batch_id = yield self.backend.batch_start()
-        page = yield self.backend.list_batch_outbound_keys_with_timestamps(
-            batch_id)
-        self.assertEqual(list(page), [])
-
-    @inlineCallbacks
-    def test_list_batch_inbound_keys_with_addresses(self):
+    def test_list_batch_inbound_messages(self):
         """
         When we ask for a list of inbound message keys with addresses, we get
         an IndexPageWrapper containing the first page of results and can ask
@@ -952,7 +693,7 @@ class RiakBackendTestMixin(object):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        keys_p1 = yield self.backend.list_batch_inbound_keys_with_addresses(
+        keys_p1 = yield self.backend.list_batch_inbound_messages(
             batch_id, max_results=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[:3])
@@ -961,14 +702,14 @@ class RiakBackendTestMixin(object):
         self.assertEqual(list(keys_p2), all_keys[3:])
 
     @inlineCallbacks
-    def test_list_batch_inbound_keys_with_addresses_range_start(self):
+    def test_list_batch_inbound_messages_range_start(self):
         """
         When we ask for a list of inbound message keys with addresses, we can
         specify a start timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        keys_p1 = yield self.backend.list_batch_inbound_keys_with_addresses(
+        keys_p1 = yield self.backend.list_batch_inbound_messages(
             batch_id, start=all_keys[-2][1], max_results=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[0:3])
@@ -977,14 +718,14 @@ class RiakBackendTestMixin(object):
         self.assertEqual(list(keys_p2), all_keys[3:-1])
 
     @inlineCallbacks
-    def test_list_batch_inbound_keys_with_addresses_range_end(self):
+    def test_list_batch_inbound_messages_range_end(self):
         """
         When we ask for a list of inbound message keys with addresses, we can
         specify an end timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        keys_p1 = yield self.backend.list_batch_inbound_keys_with_addresses(
+        keys_p1 = yield self.backend.list_batch_inbound_messages(
             batch_id, end=all_keys[1][1], max_results=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:4])
@@ -993,14 +734,14 @@ class RiakBackendTestMixin(object):
         self.assertEqual(list(keys_p2), all_keys[4:])
 
     @inlineCallbacks
-    def test_list_batch_inbound_keys_with_addresses_range(self):
+    def test_list_batch_inbound_messages_range(self):
         """
         When we ask for a list of inbound message keys with addresses, we can
         specify both ends of the range.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
-        keys_p1 = yield self.backend.list_batch_inbound_keys_with_addresses(
+        keys_p1 = yield self.backend.list_batch_inbound_messages(
             batch_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:3])
@@ -1009,18 +750,17 @@ class RiakBackendTestMixin(object):
         self.assertEqual(list(keys_p2), all_keys[3:-1])
 
     @inlineCallbacks
-    def test_list_batch_inbound_keys_with_addresses_empty(self):
+    def test_list_batch_inbound_messages_empty(self):
         """
         When we ask for a list of inbound message keys with addresses for an
         empty batch, we get an empty IndexPageWrapper.
         """
         batch_id = yield self.backend.batch_start()
-        keys_page = yield self.backend.list_batch_inbound_keys_with_addresses(
-            batch_id)
+        keys_page = yield self.backend.list_batch_inbound_messages(batch_id)
         self.assertEqual(list(keys_page), [])
 
     @inlineCallbacks
-    def test_list_batch_outbound_keys_with_addresses(self):
+    def test_list_batch_outbound_messages(self):
         """
         When we ask for a list of outbound message keys with addresses, we get
         an IndexPageWrapper containing the first page of results and can ask
@@ -1028,7 +768,7 @@ class RiakBackendTestMixin(object):
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        keys_p1 = yield self.backend.list_batch_outbound_keys_with_addresses(
+        keys_p1 = yield self.backend.list_batch_outbound_messages(
             batch_id, max_results=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[:3])
@@ -1037,14 +777,14 @@ class RiakBackendTestMixin(object):
         self.assertEqual(list(keys_p2), all_keys[3:])
 
     @inlineCallbacks
-    def test_list_batch_outbound_keys_with_addresses_range_start(self):
+    def test_list_batch_outbound_messages_range_start(self):
         """
         When we ask for a list of outbound message keys with addresses, we can
         specify a start timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        keys_p1 = yield self.backend.list_batch_outbound_keys_with_addresses(
+        keys_p1 = yield self.backend.list_batch_outbound_messages(
             batch_id, start=all_keys[-2][1], max_results=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[0:3])
@@ -1053,14 +793,14 @@ class RiakBackendTestMixin(object):
         self.assertEqual(list(keys_p2), all_keys[3:-1])
 
     @inlineCallbacks
-    def test_list_batch_outbound_keys_with_addresses_range_end(self):
+    def test_list_batch_outbound_messages_range_end(self):
         """
         When we ask for a list of outbound message keys with addresses, we can
         specify an end timestamp.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        keys_p1 = yield self.backend.list_batch_outbound_keys_with_addresses(
+        keys_p1 = yield self.backend.list_batch_outbound_messages(
             batch_id, end=all_keys[1][1], max_results=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:4])
@@ -1069,14 +809,14 @@ class RiakBackendTestMixin(object):
         self.assertEqual(list(keys_p2), all_keys[4:])
 
     @inlineCallbacks
-    def test_list_batch_outbound_keys_with_addresses_range(self):
+    def test_list_batch_outbound_messages_range(self):
         """
         When we ask for a list of outbound message keys with addresses, we can
         specify both ends of the range.
         """
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
-        keys_p1 = yield self.backend.list_batch_outbound_keys_with_addresses(
+        keys_p1 = yield self.backend.list_batch_outbound_messages(
             batch_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:3])
@@ -1085,18 +825,17 @@ class RiakBackendTestMixin(object):
         self.assertEqual(list(keys_p2), all_keys[3:-1])
 
     @inlineCallbacks
-    def test_list_batch_outbound_keys_with_addresses_empty(self):
+    def test_list_batch_outbound_messages_empty(self):
         """
         When we ask for a list of outbound message keys with addresses for an
         empty batch, we get an empty IndexPageWrapper.
         """
         batch_id = yield self.backend.batch_start()
-        keys_page = yield self.backend.list_batch_outbound_keys_with_addresses(
-            batch_id)
+        keys_page = yield self.backend.list_batch_outbound_messages(batch_id)
         self.assertEqual(list(keys_page), [])
 
     @inlineCallbacks
-    def test_list_message_event_keys_with_statuses(self):
+    def test_list_message_events(self):
         """
         When we ask for a list of event keys with statuses, we get an
         IndexPageWrapper containing the first page of results and can ask for
@@ -1105,8 +844,7 @@ class RiakBackendTestMixin(object):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
 
-        keys_p1 = yield self.backend.list_message_event_keys_with_statuses(
-            msg_id, max_results=3)
+        keys_p1 = yield self.backend.list_message_events(msg_id, max_results=3)
         # Paginated results are sorted by ascending timestamp.
         all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[:3])
@@ -1115,7 +853,7 @@ class RiakBackendTestMixin(object):
         self.assertEqual(list(keys_p2), all_keys[3:])
 
     @inlineCallbacks
-    def test_list_message_event_keys_with_statuses_no_events(self):
+    def test_list_message_events_no_events(self):
         """
         When we ask for a list of event keys with statuses for a message with
         no events, we get an empty IndexPageWrapper.
@@ -1123,18 +861,16 @@ class RiakBackendTestMixin(object):
         batch_id = yield self.backend.batch_start()
         msg = self.msg_helper.make_outbound("hello")
         yield self.backend.add_outbound_message(msg, batch_ids=[batch_id])
-        keys_page = yield self.backend.list_message_event_keys_with_statuses(
-            msg["message_id"])
+        keys_page = yield self.backend.list_message_events(msg["message_id"])
         self.assertEqual(list(keys_page), [])
 
     @inlineCallbacks
-    def test_list_message_event_keys_with_statuses_no_message(self):
+    def test_list_message_events_no_message(self):
         """
         When we ask for a list of event keys with statuses for a message that
         does not exist, we get an empty IndexPageWrapper.
         """
-        keys_page = yield self.backend.list_message_event_keys_with_statuses(
-            "badmsg")
+        keys_page = yield self.backend.list_message_events("badmsg")
         self.assertEqual(list(keys_page), [])
 
     @inlineCallbacks
@@ -1208,8 +944,7 @@ class RiakBackendTestMixin(object):
         empty IndexPageWrapper.
         """
         batch_id = yield self.backend.batch_start()
-        keys_page = yield self.backend.list_batch_events(
-            batch_id)
+        keys_page = yield self.backend.list_batch_events(batch_id)
         self.assertEqual(list(keys_page), [])
 
 

--- a/vumi_message_store/tests/test_riak_backend.py
+++ b/vumi_message_store/tests/test_riak_backend.py
@@ -694,7 +694,7 @@ class RiakBackendTestMixin(object):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
         keys_p1 = yield self.backend.list_batch_inbound_messages(
-            batch_id, max_results=3)
+            batch_id, page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[:3])
 
@@ -710,7 +710,7 @@ class RiakBackendTestMixin(object):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
         keys_p1 = yield self.backend.list_batch_inbound_messages(
-            batch_id, start=all_keys[-2][1], max_results=3)
+            batch_id, start=all_keys[-2][1], page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[0:3])
 
@@ -726,7 +726,7 @@ class RiakBackendTestMixin(object):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
         keys_p1 = yield self.backend.list_batch_inbound_messages(
-            batch_id, end=all_keys[1][1], max_results=3)
+            batch_id, end=all_keys[1][1], page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:4])
 
@@ -742,7 +742,7 @@ class RiakBackendTestMixin(object):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_inbound_message_sequence())
         keys_p1 = yield self.backend.list_batch_inbound_messages(
-            batch_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
+            batch_id, start=all_keys[-2][1], end=all_keys[1][1], page_size=2)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:3])
 
@@ -769,7 +769,7 @@ class RiakBackendTestMixin(object):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
         keys_p1 = yield self.backend.list_batch_outbound_messages(
-            batch_id, max_results=3)
+            batch_id, page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[:3])
 
@@ -785,7 +785,7 @@ class RiakBackendTestMixin(object):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
         keys_p1 = yield self.backend.list_batch_outbound_messages(
-            batch_id, start=all_keys[-2][1], max_results=3)
+            batch_id, start=all_keys[-2][1], page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[0:3])
 
@@ -801,7 +801,7 @@ class RiakBackendTestMixin(object):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
         keys_p1 = yield self.backend.list_batch_outbound_messages(
-            batch_id, end=all_keys[1][1], max_results=3)
+            batch_id, end=all_keys[1][1], page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:4])
 
@@ -817,7 +817,7 @@ class RiakBackendTestMixin(object):
         batch_id, all_keys = (
             yield self.msg_seq_helper.create_outbound_message_sequence())
         keys_p1 = yield self.backend.list_batch_outbound_messages(
-            batch_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
+            batch_id, start=all_keys[-2][1], end=all_keys[1][1], page_size=2)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:3])
 
@@ -844,7 +844,7 @@ class RiakBackendTestMixin(object):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
 
-        keys_p1 = yield self.backend.list_message_events(msg_id, max_results=3)
+        keys_p1 = yield self.backend.list_message_events(msg_id, page_size=3)
         # Paginated results are sorted by ascending timestamp.
         all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[:3])
@@ -861,7 +861,7 @@ class RiakBackendTestMixin(object):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
         keys_p1 = yield self.backend.list_message_events(
-            msg_id, start=all_keys[-2][1], max_results=3)
+            msg_id, start=all_keys[-2][1], page_size=3)
         # Paginated results are sorted by ascending timestamp.
         all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[1:4])
@@ -878,7 +878,7 @@ class RiakBackendTestMixin(object):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
         keys_p1 = yield self.backend.list_message_events(
-            msg_id, end=all_keys[1][1], max_results=3)
+            msg_id, end=all_keys[1][1], page_size=3)
         # Paginated results are sorted by ascending timestamp.
         all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[0:3])
@@ -895,7 +895,7 @@ class RiakBackendTestMixin(object):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
         keys_p1 = yield self.backend.list_message_events(
-            msg_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
+            msg_id, start=all_keys[-2][1], end=all_keys[1][1], page_size=2)
         # Paginated results are sorted by ascending timestamp.
         all_keys.reverse()
         self.assertEqual(list(keys_p1), all_keys[1:3])
@@ -934,7 +934,7 @@ class RiakBackendTestMixin(object):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
 
-        keys_p1 = yield self.backend.list_batch_events(batch_id, max_results=3)
+        keys_p1 = yield self.backend.list_batch_events(batch_id, page_size=3)
         self.assertEqual(list(keys_p1), all_keys[:3])
 
         keys_p2 = yield keys_p1.next_page()
@@ -949,7 +949,7 @@ class RiakBackendTestMixin(object):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
         keys_p1 = yield self.backend.list_batch_events(
-            batch_id, start=all_keys[-2][1], max_results=3)
+            batch_id, start=all_keys[-2][1], page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[0:3])
 
@@ -965,7 +965,7 @@ class RiakBackendTestMixin(object):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
         keys_p1 = yield self.backend.list_batch_events(
-            batch_id, end=all_keys[1][1], max_results=3)
+            batch_id, end=all_keys[1][1], page_size=3)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:4])
 
@@ -981,7 +981,7 @@ class RiakBackendTestMixin(object):
         batch_id, msg_id, all_keys = (
             yield self.msg_seq_helper.create_ack_event_sequence())
         keys_p1 = yield self.backend.list_batch_events(
-            batch_id, start=all_keys[-2][1], end=all_keys[1][1], max_results=2)
+            batch_id, start=all_keys[-2][1], end=all_keys[1][1], page_size=2)
         # Paginated results are sorted by descending timestamp.
         self.assertEqual(list(keys_p1), all_keys[1:3])
 


### PR DESCRIPTION
We currently have a number of "list message" methods that vary in the content of their responses. Now that they're all using the same index, we should simplify the API by removing the unnecessary variation.
